### PR TITLE
Additionally use 'v' string of extended handshake messages for client identification

### DIFF
--- a/src/peer/peer.cpp
+++ b/src/peer/peer.cpp
@@ -531,6 +531,11 @@ namespace bt
             {
                 stats.partial_seed = val->data().toInt() == 1;
             }
+
+            if ((val = dict->getValue(QByteArrayLiteral("v"))))
+            {
+                stats.client = val->data().toString();
+            }
         }
         catch (...)
         {


### PR DESCRIPTION
In addition to peer id based identification, the `v` string sent as part of extended handshake messages may be evaluated to identify clients, as described in [_BitTorrent Extension Protocol_, chapter '_handshake message_'](http://www.bittorrent.org/beps/bep_0010.html#handshake-message).

My tests showed that
- a majority of peers/clients send the string
- a majority of peers/clients send useful/compliant content
- clients are identified even if `PeerID::identifyClient()` fails to do so
- client identification becomes more accurate (e.g. 'Vuze' vs. 'Azureus')

Find the attached screenshot for a brief comparison of identification results using both methods. Format of column **Client**: _new method_, _old method_, _peer id_

![screenshot](https://cloud.githubusercontent.com/assets/14027079/19776742/a45473e4-9c75-11e6-8dc0-c4414c84b1dc.png)
