### PR TITLE
DHT: bootstrapping, bugfixes, code cleanup; peer ID using 'v' string of ext. handshake message

### DIFF
--- a/src/dht/announcereq.cpp
+++ b/src/dht/announcereq.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "announcereq.h"
 #include <util/log.h>
 #include <util/error.h>
@@ -25,11 +24,11 @@
 #include <bcodec/bencoder.h>
 #include "dht.h"
 
-
 using namespace bt;
 
 namespace dht
 {
+
 	AnnounceReq::AnnounceReq()
 	{
 		method = dht::ANNOUNCE_PEER;
@@ -41,7 +40,9 @@ namespace dht
 		method = dht::ANNOUNCE_PEER;
 	}
 
-	AnnounceReq::~AnnounceReq() {}
+	AnnounceReq::~AnnounceReq()
+	{
+	}
 
 	void AnnounceReq::apply(dht::DHT* dh_table)
 	{
@@ -74,17 +75,17 @@ namespace dht
 		}
 		enc.end();
 	}
-	
+
 	void AnnounceReq::parse(BDictNode* dict)
 	{
 		dht::GetPeersReq::parse(dict);
 		BDictNode* args = dict->getDict(ARG);
 		if (!args)
 			throw bt::Error("Invalid request, arguments missing");
-		
+
 		info_hash = Key(args->getByteArray("info_hash"));
 		port = args->getInt("port");
 		token = Key(args->getByteArray("token"));
 	}
-}
 
+}

--- a/src/dht/announcereq.h
+++ b/src/dht/announcereq.h
@@ -17,10 +17,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_ANNOUNCEREQ_H
 #define DHT_ANNOUNCEREQ_H
-
 
 #include "getpeersreq.h"
 
@@ -36,16 +34,17 @@ namespace dht
 		AnnounceReq();
 		AnnounceReq(const Key & id,const Key & info_hash,bt::Uint16 port,const Key & token);
 		virtual ~AnnounceReq();
-		
+
 		virtual void apply(DHT* dh_table);
 		virtual void print();
 		virtual void encode(QByteArray & arr) const;
 		virtual void parse(bt::BDictNode* dict);
-		
+
 		const Key & getToken() const {return token;}
 		bt::Uint16 getPort() const {return port;}
-		
+
 		typedef QSharedPointer<AnnounceReq> Ptr;
+
 	private:
 		bt::Uint16 port;
 		Key token;

--- a/src/dht/announcersp.cpp
+++ b/src/dht/announcersp.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "announcersp.h"
 #include <util/log.h>
 #include <util/error.h>
@@ -29,6 +28,7 @@ using namespace bt;
 
 namespace dht
 {
+
 	AnnounceRsp::AnnounceRsp() : RPCMsg(QByteArray(), ANNOUNCE_PEER, RSP_MSG, Key())
 	{
 	}
@@ -67,7 +67,7 @@ namespace dht
 		}
 		enc.end();
 	}
-	
+
 	void AnnounceRsp::parse(BDictNode* dict)
 	{
 		dht::RPCMsg::parse(dict);
@@ -77,4 +77,3 @@ namespace dht
 	}
 
 }
-

--- a/src/dht/announcersp.h
+++ b/src/dht/announcersp.h
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_ANNOUNCERSP_H
 #define DHT_ANNOUNCERSP_H
 
@@ -35,14 +34,15 @@ namespace dht
 		AnnounceRsp();
 		AnnounceRsp(const QByteArray & mtid,const Key & id);
 		virtual ~AnnounceRsp();
-		
+
 		virtual void apply(DHT* dh_table);
 		virtual void print();
 		virtual void encode(QByteArray & arr) const;
 		virtual void parse(bt::BDictNode* dict);
-		
+
 		typedef QSharedPointer<AnnounceRsp> Ptr;
 	};
+
 }
 
 #endif // DHT_ANNOUNCERSP_H

--- a/src/dht/announcetask.cpp
+++ b/src/dht/announcetask.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "announcetask.h"
 #include <util/log.h>
@@ -25,27 +25,22 @@
 #include "announcereq.h"
 #include "getpeersrsp.h"
 
-
 using namespace bt;
 
 namespace dht
 {
 
-	AnnounceTask::AnnounceTask(Database* db,
-	                           RPCServer* rpc,
-	                           Node* node,
-	                           const dht::Key & info_hash,
-	                           bt::Uint16 port,
-	                           QObject* parent)
+	AnnounceTask::AnnounceTask(Database* db, RPCServer* rpc, Node* node, const dht::Key & info_hash, bt::Uint16 port, QObject* parent)
 			: Task(rpc, node, parent),
 			info_hash(info_hash),
 			port(port),
 			db(db)
-	{}
-
+	{
+	}
 
 	AnnounceTask::~AnnounceTask()
-	{}
+	{
+	}
 
 	void AnnounceTask::handleNodes(const QByteArray& nodes, int ip_version)
 	{
@@ -53,28 +48,28 @@ namespace dht
 		Uint32 nval = nodes.size() / address_size;
 		for (Uint32 i = 0;i < nval;i++)
 		{
-			// add node to todo list
+			// Add node to todo list
 			try
 			{
 				KBucketEntry e = UnpackBucketEntry(nodes, i * address_size, ip_version);
 				if (!visited.contains(e) && todo.size() < 100)
 				{
 					todo.insert(e);
-					//	Out(SYS_DHT|LOG_DEBUG) << "DHT: GetPeers returned node " << e.getAddress().toString() << endl;
+					//Out(SYS_DHT|LOG_DEBUG) << "DHT: GetPeers returned node " << e.getAddress().toString() << endl;
 				}
 			}
 			catch (...)
 			{
-				// not enough size in buffer, just ignore the error
+				// Not enough size in buffer, just ignore the error
 			}
 		}
 	}
 
-
 	void AnnounceTask::callFinished(RPCCall* c, RPCMsg::Ptr rsp)
 	{
 		//Out(SYS_DHT|LOG_DEBUG) << "AnnounceTask::callFinished" << endl;
-		// if we do not have a get peers response, return
+
+		// If we do not have a get peers response, return
 		// announce_peer's response are just empty anyway
 		if (c->getMsgMethod() != dht::GET_PEERS)
 			return;
@@ -94,20 +89,20 @@ namespace dht
 				handleNodes(n6, 6);
 		}
 
-		// store the items in the database if there are any present
+		// Store the items in the database if there are any present
 		const DBItemList & items = gpr->getItemList();
 		for (DBItemList::const_iterator i = items.begin();i != items.end();i++)
 		{
-			//	Out(SYS_DHT|LOG_DEBUG) << "DHT: GetPeers returned item " << i->getAddress().toString() << endl;
+			//Out(SYS_DHT|LOG_DEBUG) << "DHT: GetPeers returned item " << i->getAddress().toString() << endl;
 			db->store(info_hash, *i);
-			// also add the items to the returned_items list
+			// Also add the items to the returned_items list
 			returned_items.append(*i);
 		}
 
 		if (items.size() > 0)
 			emitDataReady();
 
-		// add the peer who responded to the answered list, so we can do an announce
+		// Add the peer who responded to the answered list, so we can do an announce
 		KBucketEntry e(rsp->getOrigin(), rsp->getID());
 		if (!answered_visited.contains(e))
 		{
@@ -122,10 +117,9 @@ namespace dht
 
 	void AnnounceTask::update()
 	{
-		/*	Out(SYS_DHT|LOG_DEBUG) << "AnnounceTask::update " << endl;
-			Out(SYS_DHT|LOG_DEBUG) << "todo " << todo.count() << " ; answered " << answered.count() << endl;
-			Out(SYS_DHT|LOG_DEBUG) << "visited " << visited.count() << " ; answered_visited " << answered_visited.count() << endl;
-		*/
+		/*Out(SYS_DHT|LOG_DEBUG) << "AnnounceTask::update " << endl;
+		Out(SYS_DHT|LOG_DEBUG) << "todo " << todo.count() << " ; answered " << answered.count() << endl;
+		Out(SYS_DHT|LOG_DEBUG) << "visited " << visited.count() << " ; answered_visited " << answered_visited.count() << endl;*/
 		while (!answered.empty() && canDoRequest())
 		{
 			std::set<KBucketEntryAndToken>::iterator itr = answered.begin();
@@ -133,32 +127,31 @@ namespace dht
 			{
 				RPCMsg::Ptr anr(new AnnounceReq(node->getOurID(), info_hash, port, itr->getToken()));
 				anr->setOrigin(itr->getAddress());
-				//		Out(SYS_DHT|LOG_DEBUG) << "DHT: Announcing to " << e.getAddress().toString() << endl;
+				//Out(SYS_DHT|LOG_DEBUG) << "DHT: Announcing to " << e.getAddress().toString() << endl;
 				rpcCall(anr);
 				answered_visited.insert(*itr);
 			}
 			answered.erase(itr);
 		}
 
-		// go over the todo list and send get_peers requests
+		// Go over the todo list and send get_peers requests
 		// until we have nothing left
 		while (!todo.empty() && canDoRequest())
 		{
 			KBucketEntrySet::iterator itr = todo.begin();
-			// onLy send a findNode if we haven't allrready visited the node
+			// Only send a findNode if we haven't already visited the node
 			if (!visited.contains(*itr))
 			{
-				// send a findNode to the node
-				//		Out(SYS_DHT|LOG_DEBUG) << "DHT: Sending GetPeers to " << e.getAddress().toString() << endl;
+				// Send a findNode to the node
+				//Out(SYS_DHT|LOG_DEBUG) << "DHT: Sending GetPeers to " << e.getAddress().toString() << endl;
 				RPCMsg::Ptr gpr(new GetPeersReq(node->getOurID(), info_hash));
 				gpr->setOrigin(itr->getAddress());
 				rpcCall(gpr);
 				visited.insert(*itr);
 			}
-			// remove the entry from the todo list
+			// Remove the entry from the todo list
 			todo.erase(itr);
 		}
-
 
 		if (todo.empty() && answered.empty() && getNumOutstandingRequests() == 0 && !isFinished())
 		{
@@ -167,7 +160,7 @@ namespace dht
 		}
 		else if (answered_visited.size() > 50 || visited.size() > 200)
 		{
-			// don't let the task run forever
+			// Don't let the task run forever
 			Out(SYS_DHT | LOG_NOTICE) << "DHT: AnnounceTask done" << endl;
 			done();
 		}
@@ -182,5 +175,5 @@ namespace dht
 		returned_items.pop_front();
 		return true;
 	}
-}
 
+}

--- a/src/dht/announcetask.h
+++ b/src/dht/announcetask.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,11 +15,10 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTANNOUNCETASK_H
 #define DHTANNOUNCETASK_H
-
 
 #include "kbucket.h"
 #include "task.h"
@@ -44,17 +43,12 @@ namespace dht
 	};
 
 	/**
-		@author Joris Guisson <joris.guisson@gmail.com>
-	*/
+	 * @author Joris Guisson <joris.guisson@gmail.com>
+	 */
 	class AnnounceTask : public Task
 	{
 	public:
-		AnnounceTask(Database* db,
-		             RPCServer* rpc,
-		             Node* node,
-		             const dht::Key & info_hash,
-		             bt::Uint16 port,
-		             QObject* parent);
+		AnnounceTask(Database* db, RPCServer* rpc, Node* node, const dht::Key & info_hash, bt::Uint16 port, QObject* parent);
 		virtual ~AnnounceTask();
 
 		virtual void callFinished(RPCCall* c, RPCMsg::Ptr rsp);
@@ -68,19 +62,19 @@ namespace dht
 		 * @return false if no item to take, true else
 		 */
 		bool takeItem(DBItem & item);
-		
+
 	private:
 		void handleNodes(const QByteArray & nodes, int ip_version);
-		
+
 	private:
 		dht::Key info_hash;
 		bt::Uint16 port;
-		std::set<KBucketEntryAndToken> answered; // nodes which have answered with values
-		KBucketEntrySet answered_visited; // nodes which have answered with values which have been visited
+		std::set<KBucketEntryAndToken> answered; // Nodes which have answered with values
+		KBucketEntrySet answered_visited; // Nodes which have answered with values which have been visited
 		Database* db;
 		DBItemList returned_items;
 	};
 
 }
 
-#endif
+#endif // DHTANNOUNCETASK_H

--- a/src/dht/database.cpp
+++ b/src/dht/database.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "database.h"
 #include <arpa/inet.h>
@@ -27,6 +27,7 @@ using namespace bt;
 
 namespace dht
 {
+
 	DBItem::DBItem()
 	{
 		time_stamp = bt::CurrentTime();
@@ -44,7 +45,8 @@ namespace dht
 	}
 
 	DBItem::~DBItem()
-	{}
+	{
+	}
 
 	bool DBItem::expired(bt::TimeStamp now) const
 	{
@@ -74,16 +76,15 @@ namespace dht
 		}
 	}
 
-	///////////////////////////////////////////////
 
 	Database::Database()
 	{
 		items.setAutoDelete(true);
 	}
 
-
 	Database::~Database()
-	{}
+	{
+	}
 
 	void Database::store(const dht::Key & key, const DBItem & dbi)
 	{
@@ -117,8 +118,8 @@ namespace dht
 		while (itr != items.end())
 		{
 			DBItemList* dbl = itr->second;
-			// newer keys are inserted at the back
-			// so we can stop when we hit the first key which is not expired
+			// Newer keys are inserted at the back, so we can stop
+			// when we hit the first key which is not expired
 			while (dbl->count() > 0 && dbl->first().expired(now))
 			{
 				dbl->pop_front();
@@ -133,14 +134,14 @@ namespace dht
 		{
 			Uint8 tdata[14];
 			TimeStamp now = bt::CurrentTime();
-			// generate a hash of the ip port and the current time
+			// Generate a hash of the ip port and the current time,
 			// should prevent anybody from crapping things up
 			bt::WriteUint32(tdata, 0, addr.toIPv4Address());
 			bt::WriteUint16(tdata, 4, addr.port());
 			bt::WriteUint64(tdata, 6, now);
 
 			dht::Key token = SHA1Hash::generate(tdata, 14);
-			// keep track of the token, tokens will expire after a while
+			// Keep track of the token, tokens will expire after a while
 			tokens.insert(token, now);
 			return token;
 		}
@@ -148,14 +149,14 @@ namespace dht
 		{
 			Uint8 tdata[26];
 			TimeStamp now = bt::CurrentTime();
-			// generate a hash of the ip port and the current time
+			// Generate a hash of the ip port and the current time,
 			// should prevent anybody from crapping things up
 			memcpy(tdata, addr.toIPv6Address().c, 16);
 			bt::WriteUint16(tdata, 16, addr.port());
 			bt::WriteUint64(tdata, 18, now);
 
 			dht::Key token = SHA1Hash::generate(tdata, 26);
-			// keep track of the token, tokens will expire after a while
+			// Keep track of the token, tokens will expire after a while
 			tokens.insert(token, now);
 			return token;
 		}
@@ -163,11 +164,11 @@ namespace dht
 
 	bool Database::checkToken(const dht::Key & token, const net::Address & addr)
 	{
-		// the token must be in the map
+		// The token must be in the map
 		if (!tokens.contains(token))
 			return false;
 
-		// in the map so now get the timestamp and regenerate the token
+		// In the map so now get the timestamp and regenerate the token
 		// using the IP and port of the sender
 		TimeStamp ts = tokens[token];
 
@@ -179,8 +180,8 @@ namespace dht
 			bt::WriteUint64(tdata, 6, ts);
 			dht::Key ct = SHA1Hash::generate(tdata, 14);
 
-			// compare the generated token to the one received
-			if (token != ct)  // not good, this peer didn't went through the proper channels
+			// Compare the generated token to the one received
+			if (token != ct)  // Not good, this peer didn't went through the proper channels
 			{
 				Out(SYS_DHT | LOG_DEBUG) << "Invalid token" << endl;
 				return false;
@@ -195,15 +196,15 @@ namespace dht
 			bt::WriteUint64(tdata, 18, ts);
 
 			dht::Key ct = SHA1Hash::generate(tdata, 26);
-			// compare the generated token to the one received
-			if (token != ct)  // not good, this peer didn't went through the proper channels
+			// Compare the generated token to the one received
+			if (token != ct)  // Not good, this peer didn't went through the proper channels
 			{
 				Out(SYS_DHT | LOG_DEBUG) << "Invalid token" << endl;
 				return false;
 			}
 		}
 
-		// expire the token
+		// Expire the token
 		tokens.remove(token);
 		return true;
 	}
@@ -222,4 +223,5 @@ namespace dht
 			items.insert(key, dbl);
 		}
 	}
+
 }

--- a/src/dht/database.h
+++ b/src/dht/database.h
@@ -54,10 +54,14 @@ namespace dht
 		DBItem(const DBItem & item);
 		virtual ~DBItem();
 
-		// See if the item is expired
+		/**
+		 * See if the item is expired
+		 */
 		bool expired(bt::TimeStamp now) const;
 
-		// Get the address of an item
+		/**
+		 * Get the address of an item
+		 */
 		const net::Address & getAddress() const {return addr;}
 
 		/**
@@ -79,7 +83,7 @@ namespace dht
 	 * @author Joris Guisson
 	 *
 	 * Class where all the key value paires get stored.
-	*/
+	 */
 	class Database
 	{
 	public:
@@ -129,10 +133,14 @@ namespace dht
 		 */
 		bool checkToken(const dht::Key & token, const net::Address & addr);
 
-		// Test whether or not the DB contains a key
+		/**
+		 * Test whether or not the DB contains a key
+		 */
 		bool contains(const dht::Key & key) const;
 
-		// Insert an empty item (only if it isn't already in the DB)
+		/**
+		 * Insert an empty item (only if it isn't already in the DB)
+		 */
 		void insert(const dht::Key & key);
 
 	private:

--- a/src/dht/database.h
+++ b/src/dht/database.h
@@ -32,7 +32,14 @@
 
 namespace dht
 {
-	/// Each item may only exist for 30 minutes
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Maximum allowed age of database items before expiration. This is not
+	 * to be confused with DATABASE_EXPIRE_INTERVAL in dht.h which defines
+	 * how often the database will be checked for expired items. A value of
+	 * 30 * 60* 1000 is proposed by the reference implementation.
+	 */
 	const bt::Uint32 MAX_ITEM_AGE = 30 * 60 * 1000;
 
 	/**

--- a/src/dht/database.h
+++ b/src/dht/database.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTDATABASE_H
 #define DHTDATABASE_H
@@ -27,8 +27,6 @@
 #include <util/constants.h>
 #include <util/array.h>
 #include "key.h"
-
-
 
 namespace dht
 {
@@ -56,10 +54,10 @@ namespace dht
 		DBItem(const DBItem & item);
 		virtual ~DBItem();
 
-		/// See if the item is expired
+		// See if the item is expired
 		bool expired(bt::TimeStamp now) const;
 
-		/// Get the address of an item
+		// Get the address of an item
 		const net::Address & getAddress() const {return addr;}
 
 		/**
@@ -131,12 +129,12 @@ namespace dht
 		 */
 		bool checkToken(const dht::Key & token, const net::Address & addr);
 
-		/// Test whether or not the DB contains a key
+		// Test whether or not the DB contains a key
 		bool contains(const dht::Key & key) const;
 
-		/// Insert an empty item (only if it isn't already in the DB)
+		// Insert an empty item (only if it isn't already in the DB)
 		void insert(const dht::Key & key);
-		
+
 	private:
 		bt::PtrMap<dht::Key, DBItemList> items;
 		QMap<dht::Key, bt::TimeStamp> tokens;
@@ -144,4 +142,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTDATABASE_H

--- a/src/dht/dht.cpp
+++ b/src/dht/dht.cpp
@@ -81,6 +81,12 @@ namespace dht
 		srv->start();
 		node->loadTable(table);
 		update_timer.start(1000);
+		/**
+		 * @author Fonic <https://github.com/fonic>
+		 * Interval used for expiring database items. An interval of 5 mins
+		 * is proposed by the reference implementation. This should probably
+		 * be made user-configurable as an advanced setting.
+		 */
 		expire_timer.start(5*60*1000);
 		started();
 		if (node->getNumEntriesInRoutingTable() > 0)

--- a/src/dht/dht.h
+++ b/src/dht/dht.h
@@ -153,10 +153,14 @@ namespace dht
 		 */
 		NodeLookup* findNode(const dht::Key & id);
 
-		// Do a findNode for our node id
+		/**
+		 * Do a findNode for our node id
+		 */
 		NodeLookup* findOwnNode();
 
-		// See if it is possible to start a task
+		/**
+		 * See if it is possible to start a task
+		 */
 		bool canStartTask() const;
 
 		void start(const QString & table,const QString & key_file,bt::Uint16 port);

--- a/src/dht/dht.h
+++ b/src/dht/dht.h
@@ -57,6 +57,35 @@ namespace dht
 	class AnnounceReq;
 
 	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Interval used for expiring database items (i.e. checking the database for
+	 * expired items). This is not to be confused with MAX_ITEM_AGE in database.h
+	 * which defines _when_ database items expire). A value of 5 mins is proposed
+	 * by the reference implementation. This should probably be made user-config-
+	 * urable as an advanced setting.
+	 */
+	const bt::Uint32 DATABASE_EXPIRE_INTERVAL = 5 * 60 * 1000;
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Maximum number of concurrent tasks (i.e. outstanding DHT requests). This
+	 * used to be hard-coded in dht.cpp to a value of 7. Comparison to values in
+	 * the reference implementation is difficult, as the RI uses a finer-grained
+	 * mechanism (https://github.com/bittorrent/libbtdht/blob/master/src/DhtImpl.h,
+	 * @line 806ff, enum 'KademliaConstants'). This should probably be made user-
+	 * configurable as an advanced setting.
+	 */
+	const bt::Uint32 MAX_CONCURRENT_TASKS = 10;
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Minimum amount of RPC slots that have to be available to start a new task.
+	 * This used to be hard-coded in dht.cpp to a value of 16. This value has most
+	 * likely an internal-only scope and should not be made user-configurable.
+	 */
+	const bt::Uint32 MIN_AVAILABLE_RPC_SLOTS = 16;
+
+	/**
 		@author Joris Guisson <joris.guisson@gmail.com>
 	*/
 	class DHT : public DHTBase
@@ -113,6 +142,12 @@ namespace dht
 		void addDHTNode(const QString & host,bt::Uint16 hport);
 		
 		virtual QMap<QString, int> getClosestGoodNodes(int maxNodes);
+		
+		/**
+		 * @author Fonic <https://github.com/fonic>
+		 * Bootstrap from well-known nodes.
+		 */
+		void bootStrap();
 		
 	private slots:
 		void update();

--- a/src/dht/dht.h
+++ b/src/dht/dht.h
@@ -83,7 +83,7 @@ namespace dht
 	/**
 	 * @author Fonic <https://github.com/fonic>
 	 * Minimum amount of routing table entries bootstrapping has to yield in order
-	 * to be considered sucessful.  This should probably be made user-configurable
+	 * to be considered sucessful. This should probably be made user-configurable
 	 * as an advanced setting.
 	 */
 	const bt::Uint32 BOOTSTRAP_MIN_ENTRIES = 3;

--- a/src/dht/dht.h
+++ b/src/dht/dht.h
@@ -68,6 +68,29 @@ namespace dht
 
 	/**
 	 * @author Fonic <https://github.com/fonic>
+	 * Interval used for checking bootstrap result and retrying if necessary. One
+	 * minute should be enough time to complete bootstrapping. This should probably
+	 * be made user-configurable as an advanced setting.
+	 */
+	const bt::Uint32 BOOTSTRAP_CHECK_INTERVAL = 1 * 60 * 1000;
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Maximum number of bootstrapping retries. This should probably be made user-
+	 * configurable as an advanced setting.
+	 */
+	const bt::Uint32 BOOTSTRAP_MAX_RETRIES = 3;
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Minimum amount of routing table entries bootstrapping has to yield in order
+	 * to be considered sucessful.  This should probably be made user-configurable
+	 * as an advanced setting.
+	 */
+	const bt::Uint32 BOOTSTRAP_MIN_ENTRIES = 3;
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
 	 * Maximum number of concurrent tasks (i.e. outstanding DHT requests). This
 	 * used to be hard-coded in dht.cpp to a value of 7. Comparison to values in
 	 * the reference implementation is difficult, as the RI uses a finer-grained
@@ -80,8 +103,8 @@ namespace dht
 	/**
 	 * @author Fonic <https://github.com/fonic>
 	 * Minimum amount of RPC slots that have to be available to start a new task.
-	 * This used to be hard-coded in dht.cpp to a value of 16. This value has most
-	 * likely an internal-only scope and should not be made user-configurable.
+	 * This used to be hard-coded in dht.cpp to a value of 16. This value seems
+	 * to have an internal-only scope and should not be made user-configurable.
 	 */
 	const bt::Uint32 MIN_AVAILABLE_RPC_SLOTS = 16;
 
@@ -147,13 +170,18 @@ namespace dht
 		 * @author Fonic <https://github.com/fonic>
 		 * Bootstrap from well-known nodes.
 		 */
-		void bootStrap();
+		void bootstrap();
 		
 	private slots:
 		void update();
 		void onResolverResults(net::AddressResolver* ar);
 		void ownNodeLookupFinished(Task* t);
 		void expireDatabaseItems();
+		/**
+		 * @author Fonic <https://github.com/fonic>
+		 * Timeout handler for bootstrap timer.
+		 */
+		void checkBootstrap();
 		
 	private:
 		Node* node;
@@ -164,6 +192,12 @@ namespace dht
 		QString table_file;
 		QTimer update_timer;
 		NodeLookup* our_node_lookup;
+		/**
+		 * @author Fonic <https://github.com/fonic>
+		 * Timer for bootstrap result check, retry counter.
+		 */
+		QTimer bootstrap_timer;
+		bt::Uint32 bootstrap_retries;
 	};
 
 }

--- a/src/dht/dht.h
+++ b/src/dht/dht.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTDHT_H
 #define DHTDHT_H
@@ -28,7 +28,6 @@
 #include "key.h"
 #include "dhtbase.h"
 #include "rpcmsg.h"
-
 
 namespace net
 {
@@ -109,15 +108,15 @@ namespace dht
 	const bt::Uint32 MIN_AVAILABLE_RPC_SLOTS = 16;
 
 	/**
-		@author Joris Guisson <joris.guisson@gmail.com>
-	*/
+	 * @author Joris Guisson <joris.guisson@gmail.com>
+	 */
 	class DHT : public DHTBase
 	{
 		Q_OBJECT
 	public:
 		DHT();
 		virtual ~DHT();
-		
+
 		void ping(const PingReq & r);
 		void findNode(const FindNodeReq & r);
 		void response(const RPCMsg & r);
@@ -125,14 +124,14 @@ namespace dht
 		void announce(const AnnounceReq & r);
 		void error(const ErrMsg & r);
 		void timeout(RPCMsg::Ptr r);
-		
+
 		/**
 		 * A Peer has received a PORT message, and uses this function to alert the DHT of it.
 		 * @param ip The IP of the peer
 		 * @param port The port in the PORT message
 		 */
 		void portReceived(const QString & ip,bt::Uint16 port);
-		
+
 		/**
 		 * Do an announce on the DHT network
 		 * @param info_hash The info_hash
@@ -140,7 +139,7 @@ namespace dht
 		 * @return The task which handles this
 		 */
 		AnnounceTask* announce(const bt::SHA1Hash & info_hash,bt::Uint16 port);
-		
+
 		/**
 		 * Refresh a bucket using a find node task.
 		 * @param id The id
@@ -153,25 +152,25 @@ namespace dht
 		 * @param id The id of the key to search
 		 */
 		NodeLookup* findNode(const dht::Key & id);
-		
-		/// Do a findNode for our node id
+
+		// Do a findNode for our node id
 		NodeLookup* findOwnNode();
-		
-		/// See if it is possible to start a task
+
+		// See if it is possible to start a task
 		bool canStartTask() const;
-		
+
 		void start(const QString & table,const QString & key_file,bt::Uint16 port);
 		void stop();
 		void addDHTNode(const QString & host,bt::Uint16 hport);
-		
+
 		virtual QMap<QString, int> getClosestGoodNodes(int maxNodes);
-		
+
 		/**
 		 * @author Fonic <https://github.com/fonic>
 		 * Bootstrap from well-known nodes.
 		 */
 		void bootstrap();
-		
+
 	private slots:
 		void update();
 		void onResolverResults(net::AddressResolver* ar);
@@ -182,7 +181,7 @@ namespace dht
 		 * Timeout handler for bootstrap timer.
 		 */
 		void checkBootstrap();
-		
+
 	private:
 		Node* node;
 		RPCServer* srv;
@@ -202,4 +201,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTDHT_H

--- a/src/dht/dhtbase.cpp
+++ b/src/dht/dhtbase.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "dhtbase.h"
 
@@ -28,8 +28,8 @@ namespace dht
 		stats.num_tasks = 0;
 	}
 
-
 	DHTBase::~DHTBase()
-	{}
-}
+	{
+	}
 
+}

--- a/src/dht/dhtbase.h
+++ b/src/dht/dhtbase.h
@@ -37,9 +37,9 @@ namespace dht
 
 	struct Stats
 	{
-		// Number of peers in the routing table
+		/// Number of peers in the routing table
 		bt::Uint32 num_peers;
-		// Number of running tasks
+		/// Number of running tasks
 		bt::Uint32 num_tasks;
 	};
 
@@ -94,10 +94,14 @@ namespace dht
 		 */
 		bool isRunning() const {return running;}
 
-		// Get the DHT port
+		/**
+		 * Get the DHT port
+		 */
 		bt::Uint16 getPort() const {return port;}
 
-		// Get statistics about the DHT
+		/**
+		 * Get statistics about the DHT
+		 */
 		const dht::Stats & getStats() const {return stats;}
 
 		/**

--- a/src/dht/dhtbase.h
+++ b/src/dht/dhtbase.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTDHTBASE_H
 #define DHTDHTBASE_H
@@ -34,18 +34,18 @@ namespace bt
 namespace dht
 {
 	class AnnounceTask;
-	
+
 	struct Stats
 	{
-		/// number of peers in the routing table
+		// Number of peers in the routing table
 		bt::Uint32 num_peers;
-		/// Number of running tasks
+		// Number of running tasks
 		bt::Uint32 num_tasks;
 	};
 
 	/**
 	 * @author Joris Guisson <joris.guisson@gmail.com>
-	 * 
+	 *
 	 * Interface for DHT class, this is to keep other things separate from the inner workings
 	 * of the DHT.
 	 */
@@ -55,8 +55,7 @@ namespace dht
 	public:
 		DHTBase();
 		virtual ~DHTBase();
-		
-		
+
 		/**
 		 * Start the DHT
 		 * @param table File where the save table is located
@@ -64,24 +63,24 @@ namespace dht
 		 * @param port The port to use
 		 */
 		virtual void start(const QString & table,const QString & key_file,bt::Uint16 port) = 0;
-		
+
 		/**
 		 * Stop the DHT
 		 */
 		virtual void stop() = 0;
-		
+
 		/**
 		 * Update the DHT
 		 */
 		virtual void update() = 0;
-		
+
 		/**
 		 * A Peer has received a PORT message, and uses this function to alert the DHT of it.
 		 * @param ip The IP of the peer
 		 * @param port The port in the PORT message
 		 */
 		virtual void portReceived(const QString & ip,bt::Uint16 port) = 0;
-		
+
 		/**
 		 * Do an announce on the DHT network
 		 * @param info_hash The info_hash
@@ -89,36 +88,36 @@ namespace dht
 		 * @return The task which handles this
 		 */
 		virtual AnnounceTask* announce(const bt::SHA1Hash & info_hash,bt::Uint16 port) = 0;
-		
+
 		/**
 		 * See if the DHT is running.
 		 */
 		bool isRunning() const {return running;}
-		
-		/// Get the DHT port
+
+		// Get the DHT port
 		bt::Uint16 getPort() const {return port;}
-		
-		/// Get statistics about the DHT
+
+		// Get statistics about the DHT
 		const dht::Stats & getStats() const {return stats;}
-		
+
 		/**
 		 * Add a DHT node. This node shall be pinged immediately.
 		 * @param host The hostname or ip
 		 * @param hport The port of the host
 		 */
 		virtual void addDHTNode(const QString & host,bt::Uint16 hport) = 0;
-		
+
 		/**
-		 * Returns maxNodes number of <IP address, port> nodes 
+		 * Returns maxNodes number of <IP address, port> nodes
 		 * that are closest to ourselves and are good.
 		 * @param maxNodes maximum nr of nodes in QMap to return.
 		 */
 		virtual QMap<QString, int> getClosestGoodNodes(int maxNodes) = 0;
-		
+
 	signals:
 		void started();
 		void stopped();
-		
+
 	protected:
 		bool running;
 		bt::Uint16 port;
@@ -127,4 +126,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTDHTBASE_H

--- a/src/dht/dhtpeersource.h
+++ b/src/dht/dhtpeersource.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTDHTPEERSOURCE_H
 #define DHTDHTPEERSOURCE_H
@@ -24,20 +24,16 @@
 #include <interfaces/peersource.h>
 #include "task.h"
 
-
 namespace bt
 {
 	class WaitJob;
 	struct DHTNode;
 }
 
-
 namespace dht
 {
 	class DHTBase;
 	class AnnounceTask;
-
-	
 
 	/**
 		@author Joris Guisson <joris.guisson@gmail.com>
@@ -52,17 +48,17 @@ namespace dht
 		virtual void start();
 		virtual void stop(bt::WaitJob* wjob = 0);
 		virtual void manualUpdate();
-		
+
 		void addDHTNode(const bt::DHTNode & node);
 		void setRequestInterval(bt::Uint32 interval);
-	
+
 	private slots:
 		void onTimeout();
 		bool doRequest();
 		void onDataReady(Task* t);
 		void onFinished(Task* t);
 		void dhtStopped();
-		
+
 	private:
 		DHTBase & dh_table;
 		AnnounceTask* curr_task;
@@ -76,4 +72,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTDHTPEERSOURCE_H

--- a/src/dht/errmsg.cpp
+++ b/src/dht/errmsg.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2012 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,13 +17,11 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "errmsg.h"
 #include <bcodec/bnode.h>
 #include <util/log.h>
 #include <util/error.h>
 #include "dht.h"
-
 
 using namespace bt;
 
@@ -35,10 +33,12 @@ namespace dht
 
 	ErrMsg::ErrMsg(const QByteArray & mtid, const Key & id, const QString & msg)
 			: RPCMsg(mtid, NONE, ERR_MSG, id), msg(msg)
-	{}
+	{
+	}
 
 	ErrMsg::~ErrMsg()
-	{}
+	{
+	}
 
 	void ErrMsg::apply(dht::DHT* dh_table)
 	{
@@ -51,15 +51,16 @@ namespace dht
 	}
 
 	void ErrMsg::encode(QByteArray &) const
-	{}
-	
+	{
+	}
+
 	void ErrMsg::parse(BDictNode* dict)
 	{
 		RPCMsg::parse(dict);
 		BListNode* ln = dict->getList(ERR_DHT);
 		if (!ln)
 			throw bt::Error("Invalid error message");
-		
+
 		msg = ln->getString(1, 0);
 	}
 

--- a/src/dht/errmsg.h
+++ b/src/dht/errmsg.h
@@ -40,7 +40,9 @@ namespace dht
 		virtual void encode(QByteArray & arr) const;
 		virtual void parse(bt::BDictNode* dict);
 
-		// Get the error message
+		/**
+		 * Get the error message
+		 */
 		const QString & message() const {return msg;}
 
 		typedef QSharedPointer<ErrMsg> Ptr;

--- a/src/dht/errmsg.h
+++ b/src/dht/errmsg.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2012 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_ERRMSG_H
 #define DHT_ERRMSG_H
 
@@ -40,14 +39,16 @@ namespace dht
 		virtual void print();
 		virtual void encode(QByteArray & arr) const;
 		virtual void parse(bt::BDictNode* dict);
-		
-		/// Get the error message
+
+		// Get the error message
 		const QString & message() const {return msg;}
 
 		typedef QSharedPointer<ErrMsg> Ptr;
+
 	private:
 		QString msg;
 	};
+
 }
 
 #endif // DHT_ERRMSG_H

--- a/src/dht/findnodereq.cpp
+++ b/src/dht/findnodereq.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2012 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "findnodereq.h"
 #include <util/log.h>
 #include <util/error.h>
@@ -25,24 +24,25 @@
 #include <bcodec/bencoder.h>
 #include "dht.h"
 
-
 using namespace bt;
 
 namespace dht
 {
+
 	FindNodeReq::FindNodeReq() :
 			RPCMsg(QByteArray(), FIND_NODE, REQ_MSG, Key())
 	{
 	}
 
-
-	FindNodeReq::FindNodeReq(const Key & id, const Key & target) : 
-		RPCMsg(QByteArray(), FIND_NODE, REQ_MSG, id), 
+	FindNodeReq::FindNodeReq(const Key & id, const Key & target) :
+		RPCMsg(QByteArray(), FIND_NODE, REQ_MSG, id),
 		target(target)
-	{}
+	{
+	}
 
 	FindNodeReq::~FindNodeReq()
-	{}
+	{
+	}
 
 	void FindNodeReq::apply(dht::DHT* dh_table)
 	{
@@ -88,12 +88,10 @@ namespace dht
 				want.append(ln->getString(i, 0));
 		}
 	}
-	
+
 	bool FindNodeReq::wants(int ip_version) const
 	{
 		return want.contains(QString("n%1").arg(ip_version));
 	}
 
-
 }
-

--- a/src/dht/findnodereq.h
+++ b/src/dht/findnodereq.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2012 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_FINDNODEREQ_H
 #define DHT_FINDNODEREQ_H
 
@@ -51,6 +50,7 @@ namespace dht
 		Key target;
 		QStringList want;
 	};
+
 }
 
 #endif // DHT_FINDNODEREQ_H

--- a/src/dht/findnodersp.cpp
+++ b/src/dht/findnodersp.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "findnodersp.h"
 #include <util/log.h>
 #include <util/error.h>
@@ -25,12 +24,11 @@
 #include <bcodec/bencoder.h>
 #include "dht.h"
 
-
 using namespace bt;
-
 
 namespace dht
 {
+
 	FindNodeRsp::FindNodeRsp()
 			: RPCMsg(QByteArray(), FIND_NODE, RSP_MSG, Key())
 	{
@@ -38,9 +36,12 @@ namespace dht
 
 	FindNodeRsp::FindNodeRsp(const QByteArray & mtid, const Key & id)
 			: RPCMsg(mtid, FIND_NODE, RSP_MSG, id)
-	{}
+	{
+	}
 
-	FindNodeRsp::~FindNodeRsp() {}
+	FindNodeRsp::~FindNodeRsp()
+	{
+	}
 
 	void FindNodeRsp::apply(dht::DHT* dh_table)
 	{
@@ -63,13 +64,13 @@ namespace dht
 				enc.write(QByteArrayLiteral("id")); enc.write(id.getData(), 20);
 				if (nodes.size() > 0)
 				{
-					enc.write(QByteArrayLiteral("nodes")); 
+					enc.write(QByteArrayLiteral("nodes"));
 					enc.write(nodes);
 				}
-				
+
 				if (nodes6.size() > 0)
 				{
-					enc.write(QByteArrayLiteral("nodes6")); 
+					enc.write(QByteArrayLiteral("nodes6"));
 					enc.write(nodes6);
 				}
 			}
@@ -101,4 +102,3 @@ namespace dht
 	}
 
 }
-

--- a/src/dht/findnodersp.h
+++ b/src/dht/findnodersp.h
@@ -17,17 +17,14 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_FINDNODERSP_H
 #define DHT_FINDNODERSP_H
-
 
 #include "rpcmsg.h"
 #include "packednodecontainer.h"
 
 namespace dht
 {
-
 
 	/**
 	 * FindNode response message for DHT
@@ -46,7 +43,6 @@ namespace dht
 
 		typedef QSharedPointer<FindNodeRsp> Ptr;
 	};
-
 
 }
 

--- a/src/dht/getpeersreq.cpp
+++ b/src/dht/getpeersreq.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "getpeersreq.h"
 #include <util/log.h>
 #include <util/error.h>
@@ -25,11 +24,11 @@
 #include <bcodec/bencoder.h>
 #include "dht.h"
 
-
 using namespace bt;
 
 namespace dht
 {
+
 	GetPeersReq::GetPeersReq()
 			: RPCMsg(QByteArray(), GET_PEERS, REQ_MSG, Key())
 	{
@@ -37,10 +36,12 @@ namespace dht
 
 	GetPeersReq::GetPeersReq(const Key & id, const Key & info_hash)
 			: RPCMsg(QByteArray(), GET_PEERS, REQ_MSG, id), info_hash(info_hash)
-	{}
+	{
+	}
 
 	GetPeersReq::~GetPeersReq()
-	{}
+	{
+	}
 
 	void GetPeersReq::apply(dht::DHT* dh_table)
 	{
@@ -86,12 +87,10 @@ namespace dht
 				want.append(ln->getString(i, 0));
 		}
 	}
-	
+
 	bool GetPeersReq::wants(int ip_version) const
 	{
 		return want.contains(QString("n%1").arg(ip_version));
 	}
 
-
 }
-

--- a/src/dht/getpeersreq.h
+++ b/src/dht/getpeersreq.h
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_GETPEERSREQ_H
 #define DHT_GETPEERSREQ_H
 
@@ -36,22 +35,22 @@ namespace dht
 		GetPeersReq();
 		GetPeersReq(const Key & id,const Key & info_hash);
 		virtual ~GetPeersReq();
-		
+
 		const Key & getInfoHash() const {return info_hash;}
 		bool wants(int ip_version) const;
-		
+
 		virtual void apply(DHT* dh_table);
 		virtual void print();
 		virtual void encode(QByteArray & arr) const;
 		virtual void parse(bt::BDictNode* dict);
-		
+
 		typedef QSharedPointer<GetPeersReq> Ptr;
-		
+
 	protected:
 		Key info_hash;
 		QStringList want;
 	};
-	
+
 }
 
 #endif // DHT_GETPEERSREQ_H

--- a/src/dht/getpeersrsp.cpp
+++ b/src/dht/getpeersrsp.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "getpeersrsp.h"
 #include <util/log.h>
 #include <util/error.h>
@@ -26,30 +25,32 @@
 #include <bcodec/bnode.h>
 #include "dht.h"
 
-
 using namespace bt;
 
 namespace dht
 {
+
 	GetPeersRsp::GetPeersRsp()
 			: RPCMsg(QByteArray(), dht::GET_PEERS, dht::RSP_MSG, Key())
 	{
 	}
 
 	GetPeersRsp::GetPeersRsp(const QByteArray & mtid, const Key & id, const Key & token)
-			: RPCMsg(mtid, dht::GET_PEERS, dht::RSP_MSG, id), 
+			: RPCMsg(mtid, dht::GET_PEERS, dht::RSP_MSG, id),
 			token(token)
 	{
 	}
 
 	GetPeersRsp::GetPeersRsp(const QByteArray & mtid, const Key & id, const DBItemList & values, const Key & token)
-			: RPCMsg(mtid, dht::GET_PEERS, dht::RSP_MSG, id), 
-			token(token), 
+			: RPCMsg(mtid, dht::GET_PEERS, dht::RSP_MSG, id),
+			token(token),
 			items(values)
-	{}
+	{
+	}
 
 	GetPeersRsp::~GetPeersRsp()
-	{}
+	{
+	}
 
 	void GetPeersRsp::apply(dht::DHT* dh_table)
 	{
@@ -67,24 +68,24 @@ namespace dht
 		BEncoder enc(new BEncoderBufferOutput(arr));
 		enc.beginDict();
 		{
-			enc.write(RSP); 
+			enc.write(RSP);
 			enc.beginDict();
 			{
 				enc.write(QByteArrayLiteral("id")); enc.write(id.getData(), 20);
 				if (nodes.size() > 0)
 				{
-					enc.write(QByteArrayLiteral("nodes")); 
+					enc.write(QByteArrayLiteral("nodes"));
 					enc.write(nodes);
 				}
-				
+
 				if (nodes6.size() > 0)
 				{
-					enc.write(QByteArrayLiteral("nodes6")); 
+					enc.write(QByteArrayLiteral("nodes6"));
 					enc.write(nodes6);
 				}
-				
+
 				enc.write(QByteArrayLiteral("token")); enc.write(token.getData(), 20);
-				
+
 				if (items.size() > 0)
 				{
 					enc.write(QByteArrayLiteral("values")); enc.beginList();
@@ -139,7 +140,7 @@ namespace dht
 				}
 			}
 		}
-		
+
 		if (args->getValue("nodes") || args->getList("nodes6"))
 		{
 			BValueNode* v = args->getValue("nodes");
@@ -151,5 +152,5 @@ namespace dht
 				nodes6 = v->data().toByteArray();
 		}
 	}
-}
 
+}

--- a/src/dht/getpeersrsp.h
+++ b/src/dht/getpeersrsp.h
@@ -17,10 +17,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_GETPEERSRSP_H
 #define DHT_GETPEERSRSP_H
-
 
 #include "rpcmsg.h"
 #include "packednodecontainer.h"
@@ -50,6 +48,7 @@ namespace dht
 		bool containsValues() const {return nodes.size() == 0;}
 
 		typedef QSharedPointer<GetPeersRsp> Ptr;
+
 	private:
 		Key token;
 		DBItemList items;

--- a/src/dht/kbucket.cpp
+++ b/src/dht/kbucket.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "kbucket.h"
 #include <netinet/in.h>
@@ -31,11 +31,11 @@
 #include "task.h"
 #include "pingreq.h"
 
-
 using namespace bt;
 
 namespace dht
 {
+
 	KBucket::KBucket(RPCServerInterface* srv, const dht::Key& our_id) :
 			RPCCallListener(0),
 			min_key(Key::min()),
@@ -45,9 +45,7 @@ namespace dht
 			last_modified(bt::CurrentTime()),
 			refresh_task(0)
 	{
-
 	}
-
 
 	KBucket::KBucket(const dht::Key & min_key, const dht::Key & max_key, dht::RPCServerInterface* srv, const dht::Key& our_id) :
 			RPCCallListener(0),
@@ -60,9 +58,9 @@ namespace dht
 	{
 	}
 
-
 	KBucket::~KBucket()
-	{}
+	{
+	}
 
 	bool KBucket::keyInRange(const dht::Key& k) const
 	{
@@ -73,13 +71,12 @@ namespace dht
 	{
 		if(!keyInRange(our_id))
 			return false;
-		
+
 		if(min_key + dht::K >= max_key)
 			return false;
-		
+
 		return true;
 	}
-
 
 	std::pair<KBucket::Ptr, KBucket::Ptr> KBucket::split() throw (KBucket::UnableToSplit)
 	{
@@ -118,7 +115,7 @@ namespace dht
 			return false;
 		}
 
-		// insert if not already in the list and we still have room
+		// Insert if not already in the list and we still have room
 		if (i == entries.end() && entries.count() < (int) dht::K)
 		{
 			entries.append(entry);
@@ -133,7 +130,7 @@ namespace dht
 			}
 			else
 			{
-				// ping questionable nodes when replacing a bad one fails
+				// Ping questionable nodes when replacing a bad one fails
 				pingQuestionable(entry);
 			}
 		}
@@ -150,16 +147,14 @@ namespace dht
 			return;
 
 		KBucketEntry entry = pending_entries_busy_pinging[c];
-		pending_entries_busy_pinging.remove(c); // call is done so erase it
+		pending_entries_busy_pinging.remove(c); // Call is done so erase it
 
-		// we have a response so try to find the next bad or questionable node
-		// if we do not have room see if we can get rid of some bad peers
-		if (!replaceBadEntry(entry)) // if no bad peers ping a questionable one
+		// We have a response so try to find the next bad or questionable node
+		// If we do not have room see if we can get rid of some bad peers
+		if (!replaceBadEntry(entry)) // If no bad peers ping a questionable one
 			pingQuestionable(entry);
 
 	}
-
-
 
 	void KBucket::onTimeout(RPCCall* c)
 	{
@@ -168,7 +163,7 @@ namespace dht
 
 		KBucketEntry entry = pending_entries_busy_pinging[c];
 
-		// replace the entry which timed out
+		// Replace the entry which timed out
 		QList<KBucketEntry>::iterator i;
 		for (i = entries.begin();i != entries.end();i++)
 		{
@@ -181,13 +176,13 @@ namespace dht
 				break;
 			}
 		}
-		pending_entries_busy_pinging.remove(c); // call is done so erase it
-		// see if we can do another pending entry
+		pending_entries_busy_pinging.remove(c); // Call is done so erase it
+		// See if we can do another pending entry
 		if (pending_entries_busy_pinging.count() < 2 && pending_entries.count() > 0)
 		{
 			KBucketEntry pe = pending_entries.front();
 			pending_entries.pop_front();
-			if (!replaceBadEntry(pe)) // if no bad peers ping a questionable one
+			if (!replaceBadEntry(pe)) // If no bad peers ping a questionable one
 				pingQuestionable(pe);
 		}
 	}
@@ -196,12 +191,12 @@ namespace dht
 	{
 		if (pending_entries_busy_pinging.count() >= 2)
 		{
-			pending_entries.append(replacement_entry); // lets not have to many pending_entries calls going on
+			pending_entries.append(replacement_entry); // Let's not have to many pending_entries calls going on
 			return;
 		}
 
+		// We haven't found any bad ones so try the questionable ones
 		QList<KBucketEntry>::iterator i;
-		// we haven't found any bad ones so try the questionable ones
 		for (i = entries.begin();i != entries.end();i++)
 		{
 			KBucketEntry & e = *i;
@@ -215,7 +210,7 @@ namespace dht
 				{
 					e.onPingQuestionable();
 					c->addListener(this);
-					// add the pending entry
+					// Add the pending entry
 					pending_entries_busy_pinging.insert(c, replacement_entry);
 					return;
 				}
@@ -231,7 +226,7 @@ namespace dht
 			KBucketEntry & e = *i;
 			if (e.isBad())
 			{
-				// bad one get rid of it
+				// Bad one, get rid of it
 				last_modified = bt::CurrentTime();
 				entries.erase(i);
 				entries.append(entry);
@@ -289,8 +284,6 @@ namespace dht
 		last_modified = bt::CurrentTime();
 	}
 
-
-
 	void KBucket::save(bt::BEncoder & enc)
 	{
 		enc.beginDict();
@@ -341,7 +334,7 @@ namespace dht
 			BDictNode* entry = entry_list->getDict(i);
 			if (!entry)
 				continue;
-			
+
 			Key id = Key(entry->getByteArray("id"));
 			QByteArray addr = entry->getByteArray("address");
 			if (addr.size() == 6)
@@ -354,7 +347,6 @@ namespace dht
 				memcpy(ip.c, addr.data(), 16);
 				entries.append(KBucketEntry(net::Address(ip, bt::ReadUint16((const Uint8*)addr.data(), 16)), id));
 			}
-
 		}
 	}
 
@@ -374,4 +366,3 @@ namespace dht
 	}
 
 }
-

--- a/src/dht/kbucket.h
+++ b/src/dht/kbucket.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTKBUCKET_H
 #define DHTKBUCKET_H
@@ -60,10 +60,9 @@ namespace dht
 	/**
 	 * @author Joris Guisson
 	 *
-	 * A KBucket is just a list of KBucketEntry objects.
-	 * The list is sorted by time last seen :
-	 * The first element is the least recently seen, the last
-	 * the most recently seen.
+	 * A KBucket is just a list of KBucketEntry objects. The list is sorted
+	 * by time last seen, the first element is the least recently seen, the
+	 * last the most recently seen.
 	 */
 	class KBucket : public RPCCallListener
 	{
@@ -73,31 +72,31 @@ namespace dht
 		KBucket(RPCServerInterface* srv, const Key & our_id);
 		KBucket(const dht::Key & min_key, const dht::Key & max_key, RPCServerInterface* srv, const Key & our_id);
 		virtual ~KBucket();
-		
+
 		typedef QSharedPointer<KBucket> Ptr;
-		
-		/// Get the min key
+
+		// Get the min key
 		const dht::Key & minKey() const {return min_key;}
-		
-		/// Get the max key
+
+		// Get the max key
 		const dht::Key & maxKey() const {return max_key;}
 
-		/// Does the key k lies in in the range of this bucket
+		// Does the key k lies in in the range of this bucket
 		bool keyInRange(const dht::Key & k) const;
-		
-		/// Are we allowed to split
+
+		// Are we allowed to split
 		bool splitAllowed() const;
-		
-		class UnableToSplit
-		{};
-		
+
+		class UnableToSplit {};
+
 		/**
-		 * Split the bucket in two new buckets, each containing half the range of the original one.
+		 * Split the bucket in two new buckets, each containing half the range
+		 * of the original one.
 		 * @return A pair of KBucket's
 		 * @throw UnableToSplit if something goes wrong
 		 */
 		std::pair<KBucket::Ptr, KBucket::Ptr> split() throw (UnableToSplit);
-		
+
 		/**
 		 * Inserts an entry into the bucket.
 		 * @param entry The entry to insert
@@ -105,18 +104,18 @@ namespace dht
 		 */
 		bool insert(const KBucketEntry & entry);
 
-		/// Get the least recently seen node
+		// Get the least recently seen node
 		const KBucketEntry & leastRecentlySeen() const {return entries[0];}
 
-		/// Get the number of entries
+		// Get the number of entries
 		bt::Uint32 getNumEntries() const {return entries.count();}
 
-		/// See if this bucket contains an entry
+		// See if this bucket contains an entry
 		bool contains(const KBucketEntry & entry) const;
 
 		/**
-		 * Find the K closest entries to a key and store them in the KClosestNodesSearch
-		 * object.
+		 * Find the K closest entries to a key and store them in the KClosest
+		 * NodesSearch object.
 		 * @param kns The object to storre the search results
 		 */
 		void findKClosestNodes(KClosestNodesSearch & kns);
@@ -127,19 +126,19 @@ namespace dht
 		 */
 		bool onTimeout(const net::Address & addr);
 
-		/// Check if the bucket needs to be refreshed
+		// Check if the bucket needs to be refreshed
 		bool needsToBeRefreshed() const;
 
-		/// save the bucket to a file
+		// Save the bucket to a file
 		void save(bt::BEncoder & enc);
 
-		/// Load the bucket from a file
+		// Load the bucket from a file
 		void load(bt::BDictNode* dict);
 
-		/// Update the refresh timer of the bucket
+		// Update the refresh timer of the bucket
 		void updateRefreshTimer();
 
-		/// Set the refresh task
+		// Set the refresh task
 		void setRefreshTask(Task* t);
 
 	private:
@@ -150,7 +149,7 @@ namespace dht
 
 	private slots:
 		void onFinished(Task* t);
-		
+
 	private:
 		dht::Key min_key, max_key;
 		QList<KBucketEntry> entries, pending_entries;
@@ -160,6 +159,7 @@ namespace dht
 		mutable bt::TimeStamp last_modified;
 		Task* refresh_task;
 	};
+
 }
 
 template <class T>
@@ -168,4 +168,4 @@ inline uint qHash(const T & e)
 	return e.hash();
 }
 
-#endif
+#endif // DHTKBUCKET_H

--- a/src/dht/kbucket.h
+++ b/src/dht/kbucket.h
@@ -75,16 +75,24 @@ namespace dht
 
 		typedef QSharedPointer<KBucket> Ptr;
 
-		// Get the min key
+		/**
+		 * Get the min key
+		 */
 		const dht::Key & minKey() const {return min_key;}
 
-		// Get the max key
+		/**
+		 * Get the max key
+		 */
 		const dht::Key & maxKey() const {return max_key;}
 
-		// Does the key k lies in in the range of this bucket
+		/**
+		 * Check if key lies in the range of this bucket
+		 */
 		bool keyInRange(const dht::Key & k) const;
 
-		// Are we allowed to split
+		/**
+		 * Check if we are allowed to split
+		 */
 		bool splitAllowed() const;
 
 		class UnableToSplit {};
@@ -104,13 +112,19 @@ namespace dht
 		 */
 		bool insert(const KBucketEntry & entry);
 
-		// Get the least recently seen node
+		/**
+		 * Get the least recently seen node
+		 */
 		const KBucketEntry & leastRecentlySeen() const {return entries[0];}
 
-		// Get the number of entries
+		/**
+		 * Get the number of entries
+		 */
 		bt::Uint32 getNumEntries() const {return entries.count();}
 
-		// See if this bucket contains an entry
+		/**
+		 * Check if this bucket contains an entry
+		 */
 		bool contains(const KBucketEntry & entry) const;
 
 		/**
@@ -126,19 +140,29 @@ namespace dht
 		 */
 		bool onTimeout(const net::Address & addr);
 
-		// Check if the bucket needs to be refreshed
+		/**
+		 * Check if the bucket needs to be refreshed
+		 */
 		bool needsToBeRefreshed() const;
 
-		// Save the bucket to a file
+		/**
+		 * Save the bucket to a file
+		 */
 		void save(bt::BEncoder & enc);
 
-		// Load the bucket from a file
+		/**
+		 * Load the bucket from a file
+		 */
 		void load(bt::BDictNode* dict);
 
-		// Update the refresh timer of the bucket
+		/**
+		 * Update the refresh timer of the bucket
+		 */
 		void updateRefreshTimer();
 
-		// Set the refresh task
+		/**
+		 * Set the refresh task
+		 */
 		void setRefreshTask(Task* t);
 
 	private:

--- a/src/dht/kbucket.h
+++ b/src/dht/kbucket.h
@@ -39,10 +39,23 @@ namespace dht
 	class KClosestNodesSearch;
 	class Task;
 
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Number of nodes to find in searches. The reference implementation
+	 * proposes a value of 8. This should probably be made user-configurable
+	 * as an advanced setting.
+	 */
 	const bt::Uint32 K = 20;
-	const bt::Uint32 BUCKET_MAGIC_NUMBER = 0xB0C4B0C4;
-	const bt::Uint32 BUCKET_REFRESH_INTERVAL = 15 * 60 * 1000;
 
+	const bt::Uint32 BUCKET_MAGIC_NUMBER = 0xB0C4B0C4;
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Interval defining how often to refresh buckets. The specification
+	 * proposes an interval of 15 mins. This should probably be made user-
+	 * configurable as an advanced setting.
+	 */
+	const bt::Uint32 BUCKET_REFRESH_INTERVAL = 15 * 60 * 1000;
 
 	/**
 	 * @author Joris Guisson

--- a/src/dht/kbucketentry.cpp
+++ b/src/dht/kbucketentry.cpp
@@ -17,13 +17,13 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "kbucketentry.h"
 #include <util/log.h>
 #include <util/functions.h>
 
 namespace dht
 {
+
 	KBucketEntry::KBucketEntry()
 	{
 		last_responded = bt::CurrentTime();
@@ -45,11 +45,12 @@ namespace dht
 			last_responded(other.last_responded),
 			failed_queries(other.failed_queries),
 			questionable_pings(other.questionable_pings)
-	{}
-
+	{
+	}
 
 	KBucketEntry::~KBucketEntry()
-	{}
+	{
+	}
 
 	KBucketEntry & KBucketEntry::operator = (const KBucketEntry & other)
 	{
@@ -82,7 +83,6 @@ namespace dht
 			return false;
 	}
 
-
 	bool KBucketEntry::isBad() const
 	{
 		if (isGood())
@@ -94,7 +94,7 @@ namespace dht
 	void KBucketEntry::hasResponded()
 	{
 		last_responded = bt::CurrentTime();
-		failed_queries = 0; // reset failed queries
+		failed_queries = 0; // Reset failed queries
 		questionable_pings = 0;
 	}
 
@@ -104,4 +104,3 @@ namespace dht
 	}
 
 }
-

--- a/src/dht/kbucketentry.h
+++ b/src/dht/kbucketentry.h
@@ -66,37 +66,59 @@ namespace dht
 		 */
 		KBucketEntry & operator = (const KBucketEntry & other);
 
-		// Equality operator
+		/**
+		 * Equality operator
+		 */
 		bool operator == (const KBucketEntry & entry) const;
 
-		// Get the socket address of the node
+		/**
+		 * Get the socket address of the node
+		 */
 		const net::Address & getAddress() const {return addr;}
 
-		// Get it's ID
+		/**
+		 * Get it's ID
+		 */
 		const Key & getID() const {return node_id;}
 
-		// Is this node a good node
+		/**
+		 * Is this node a good node
+		 */
 		bool isGood() const;
 
-		// Is this node questionable (haven't heard from it in the last 15 minutes)
+		/**
+		 * Is this node questionable (haven't heard from it in the last 15 minutes)
+		 */
 		bool isQuestionable() const;
 
-		// Is it a bad node. (Hasn't responded to a query
+		/**
+		 * Is it a bad node. (hasn't responded to a query)
+		 */
 		bool isBad() const;
 
-		// Signal the entry that the peer has responded
+		/**
+		 * Signal the entry that the peer has responded
+		 */
 		void hasResponded();
 
-		// A request timed out
+		/**
+		 * A request timed out
+		 */
 		void requestTimeout() {failed_queries++;}
 
-		// The entry has been pinged because it is questionable
+		/**
+		 * The entry has been pinged because it is questionable
+		 */
 		void onPingQuestionable() {questionable_pings++;}
 
-		// The null entry
+		/**
+		 * The null entry
+		 */
 		static KBucketEntry null;
 
-		// < operator
+		/**
+		 * < operator
+		 */
 		bool operator < (const KBucketEntry & entry) const;
 
 	private:

--- a/src/dht/kbucketentry.h
+++ b/src/dht/kbucketentry.h
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_KBUCKETENTRY_H
 #define DHT_KBUCKETENTRY_H
 
@@ -57,7 +56,7 @@ namespace dht
 		 */
 		KBucketEntry(const KBucketEntry & other);
 
-		/// Destructor
+		// Destructor
 		virtual ~KBucketEntry();
 
 		/**
@@ -67,37 +66,37 @@ namespace dht
 		 */
 		KBucketEntry & operator = (const KBucketEntry & other);
 
-		/// Equality operator
+		// Equality operator
 		bool operator == (const KBucketEntry & entry) const;
 
-		/// Get the socket address of the node
+		// Get the socket address of the node
 		const net::Address & getAddress() const {return addr;}
 
-		/// Get it's ID
+		// Get it's ID
 		const Key & getID() const {return node_id;}
 
-		/// Is this node a good node
+		// Is this node a good node
 		bool isGood() const;
 
-		/// Is this node questionable (haven't heard from it in the last 15 minutes)
+		// Is this node questionable (haven't heard from it in the last 15 minutes)
 		bool isQuestionable() const;
 
-		/// Is it a bad node. (Hasn't responded to a query
+		// Is it a bad node. (Hasn't responded to a query
 		bool isBad() const;
 
-		/// Signal the entry that the peer has responded
+		// Signal the entry that the peer has responded
 		void hasResponded();
 
-		/// A request timed out
+		// A request timed out
 		void requestTimeout() {failed_queries++;}
 
-		/// The entry has been pinged because it is questionable
+		// The entry has been pinged because it is questionable
 		void onPingQuestionable() {questionable_pings++;}
 
-		/// The null entry
+		// The null entry
 		static KBucketEntry null;
 
-		/// < operator
+		// < operator
 		bool operator < (const KBucketEntry & entry) const;
 
 	private:

--- a/src/dht/kbuckettable.cpp
+++ b/src/dht/kbuckettable.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "kbuckettable.h"
 #include <QFile>
 #include <util/log.h>
@@ -28,8 +27,6 @@
 #include <bcodec/bnode.h>
 #include "nodelookup.h"
 #include "dht.h"
-
-
 
 using namespace bt;
 
@@ -47,40 +44,38 @@ namespace dht
 
 	void KBucketTable::insert(const dht::KBucketEntry& entry, dht::RPCServerInterface* srv)
 	{
-		if(buckets.empty())
+		if (buckets.empty())
 		{
 			KBucket::Ptr initial(new KBucket(srv, our_id));
 			buckets.push_back(initial);
 		}
 
-
 		KBucketList::iterator kb = findBucket(entry.getID());
 
-		// return if we can't find a bucket, should never happen'
-		if(kb == buckets.end())
+		// Return if we can't find a bucket, should never happen'
+		if (kb == buckets.end())
 		{
 			Out(SYS_DHT | LOG_IMPORTANT) << "Unable to find bucket !" << endl;
 			return;
 		}
 
-		// insert it into the bucket
+		// Insert it into the bucket
 		try
 		{
-			if((*kb)->insert(entry))
+			if ((*kb)->insert(entry))
 			{
 				// Bucket needs to be splitted
 				std::pair<KBucket::Ptr, KBucket::Ptr> result = (*kb)->split();
-/*
-				Out(SYS_DHT | LOG_DEBUG) << "Splitting bucket " << (*kb)->minKey().toString() << "-" << (*kb)->maxKey().toString() << endl;
+				/*Out(SYS_DHT | LOG_DEBUG) << "Splitting bucket " << (*kb)->minKey().toString() << "-" << (*kb)->maxKey().toString() << endl;
 				Out(SYS_DHT | LOG_DEBUG) << "L: " << result.first->minKey().toString() << "-" << result.first->maxKey().toString() << endl;
 				Out(SYS_DHT | LOG_DEBUG) << "L range: " << (result.first->maxKey() - result.first->minKey()).toString() << endl;
 				Out(SYS_DHT | LOG_DEBUG) << "R: " << result.second->minKey().toString() << "-" << result.second->maxKey().toString() << endl;
-				Out(SYS_DHT | LOG_DEBUG) << "R range: " << (result.second->maxKey() - result.second->minKey()).toString() << endl;
-*/
+				Out(SYS_DHT | LOG_DEBUG) << "R range: " << (result.second->maxKey() - result.second->minKey()).toString() << endl;*/
+
 				buckets.insert(kb, result.first);
 				buckets.insert(kb, result.second);
 				buckets.erase(kb);
-				if(result.first->keyInRange(entry.getID()))
+				if (result.first->keyInRange(entry.getID()))
 					result.first->insert(entry);
 				else
 					result.second->insert(entry);
@@ -92,7 +87,6 @@ namespace dht
 			Out(SYS_DHT | LOG_IMPORTANT) << "Unable to split buckets further !" << endl;
 			return;
 		}
-
 	}
 
 	int KBucketTable::numEntries() const
@@ -102,7 +96,6 @@ namespace dht
 		{
 			count += (*i)->getNumEntries();
 		}
-
 		return count;
 	}
 
@@ -110,10 +103,9 @@ namespace dht
 	{
 		for(KBucketList::iterator i = buckets.begin(); i != buckets.end(); i++)
 		{
-			if((*i)->keyInRange(id))
+			if ((*i)->keyInRange(id))
 				return i;
 		}
-
 		return buckets.end();
 	}
 
@@ -122,12 +114,12 @@ namespace dht
 		for(KBucketList::iterator i = buckets.begin(); i != buckets.end(); i++)
 		{
 			KBucket::Ptr b = *i;
-			if(b->needsToBeRefreshed())
+			if (b->needsToBeRefreshed())
 			{
-				// the key needs to be the refreshed
+				// The key needs to be the refreshed
 				dht::Key m = dht::Key::mid(b->minKey(), b->maxKey());
 				NodeLookup* nl = dh_table->refreshBucket(m, *b);
-				if(nl)
+				if (nl)
 					b->setRefreshTask(nl);
 			}
 		}
@@ -138,7 +130,7 @@ namespace dht
 		for(KBucketList::iterator i = buckets.begin(); i != buckets.end(); i++)
 		{
 			KBucket::Ptr b = *i;
-			if(b->onTimeout(addr))
+			if (b->onTimeout(addr))
 				return;
 		}
 	}
@@ -146,7 +138,7 @@ namespace dht
 	void KBucketTable::loadTable(const QString& file, RPCServerInterface* srv)
 	{
 		QFile fptr(file);
-		if(!fptr.open(QIODevice::ReadOnly))
+		if (!fptr.open(QIODevice::ReadOnly))
 		{
 			Out(SYS_DHT | LOG_IMPORTANT) << "DHT: Cannot open file " << file << " : " << fptr.errorString() << endl;
 			return;
@@ -158,13 +150,13 @@ namespace dht
 			bt::BDecoder dec(data, false, 0);
 
 			QScopedPointer<BListNode> bucket_list(dec.decodeList());
-			if(!bucket_list)
+			if (!bucket_list)
 				return;
 
 			for(bt::Uint32 i = 0; i < bucket_list->getNumChildren(); i++)
 			{
 				BDictNode* dict = bucket_list->getDict(i);
-				if(!dict)
+				if (!dict)
 					continue;
 
 				KBucket::Ptr bucket(new KBucket(srv, our_id));
@@ -181,7 +173,7 @@ namespace dht
 	void KBucketTable::saveTable(const QString& file)
 	{
 		bt::File fptr;
-		if(!fptr.open(file, "wb"))
+		if (!fptr.open(file, "wb"))
 		{
 			Out(SYS_DHT | LOG_IMPORTANT) << "DHT: Cannot open file " << file << " : " << fptr.errorString() << endl;
 			return;

--- a/src/dht/kbuckettable.h
+++ b/src/dht/kbuckettable.h
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_KBUCKETTABLE_H
 #define DHT_KBUCKETTABLE_H
 
@@ -26,7 +25,7 @@
 
 namespace dht
 {
-	
+
 	/**
 	 * Holds a table of buckets.
 	 */
@@ -35,32 +34,32 @@ namespace dht
 	public:
 		KBucketTable(const Key & our_id);
 		virtual ~KBucketTable();
-		
-		/// Insert a KBucketEntry into the table
+
+		// Insert a KBucketEntry into the table
 		void insert(const KBucketEntry & entry, RPCServerInterface* srv);
-		
-		/// Get the number of entries
+
+		// Get the number of entries
 		int numEntries() const;
-		
-		/// Refresh the buckets
+
+		// Refresh the buckets
 		void refreshBuckets(DHT* dh_table);
-		
-		/// Timeout happened
+
+		// Timeout happened
 		void onTimeout(const net::Address & addr);
-		
-		/// Load the table from a file
+
+		// Load the table from a file
 		void loadTable(const QString& file, dht::RPCServerInterface* srv);
-		
-		/// Save table to a file
+
+		// Save table to a file
 		void saveTable(const QString & file);
-		
-		/// FInd the K closest nodes
+
+		// FInd the K closest nodes
 		void findKClosestNodes(KClosestNodesSearch & kns);
-		
+
 	private:
 		typedef std::list<KBucket::Ptr> KBucketList;
 		KBucketList::iterator findBucket(const dht::Key & id);
-		
+
 	private:
 		Key our_id;
 		KBucketList buckets;

--- a/src/dht/kbuckettable.h
+++ b/src/dht/kbuckettable.h
@@ -35,25 +35,39 @@ namespace dht
 		KBucketTable(const Key & our_id);
 		virtual ~KBucketTable();
 
-		// Insert a KBucketEntry into the table
+		/**
+		 * Insert a KBucketEntry into the table
+		 */
 		void insert(const KBucketEntry & entry, RPCServerInterface* srv);
 
-		// Get the number of entries
+		/**
+		 * Get the number of entries
+		 */
 		int numEntries() const;
 
-		// Refresh the buckets
+		/**
+		 * Refresh the buckets
+		 */
 		void refreshBuckets(DHT* dh_table);
 
-		// Timeout happened
+		/**
+		 * Timeout happened
+		 */
 		void onTimeout(const net::Address & addr);
 
-		// Load the table from a file
+		/**
+		 * Load the table from a file
+		 */
 		void loadTable(const QString& file, dht::RPCServerInterface* srv);
 
-		// Save table to a file
+		/**
+		 * Save table to a file
+		 */
 		void saveTable(const QString & file);
 
-		// FInd the K closest nodes
+		/**
+		 * Find the K closest nodes
+		 */
 		void findKClosestNodes(KClosestNodesSearch & kns);
 
 	private:

--- a/src/dht/kclosestnodessearch.cpp
+++ b/src/dht/kclosestnodessearch.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "kclosestnodessearch.h"
 #include <util/functions.h>
@@ -30,39 +30,37 @@ namespace dht
 
 	KClosestNodesSearch::KClosestNodesSearch(const dht::Key & key, Uint32 max_entries)
 			: key(key), max_entries(max_entries)
-	{}
-
+	{
+	}
 
 	KClosestNodesSearch::~KClosestNodesSearch()
-	{}
-
+	{
+	}
 
 	void KClosestNodesSearch::tryInsert(const KBucketEntry & e)
 	{
-		// calculate distance between key and e
+		// Calculate distance between key and e
 		dht::Key d = dht::Key::distance(key, e.getID());
 
 		if (emap.size() < max_entries)
 		{
-			// room in the map so just insert
+			// Room in the map so just insert
 			emap.insert(std::make_pair(d, e));
 		}
 		else
 		{
-			// now find the max distance
-			// seeing that the last element of the map has also
-			// the biggest distance to key (std::map is sorted on the distance)
-			// we just take the last
+			// Now find the max distance. Seeing that the last element of the
+			// map has also the biggest distance to key (std::map is sorted on
+			// the distance) we just take the last
 			const dht::Key & max = emap.rbegin()->first;
 			if (d < max)
 			{
-				// insert if d is smaller then max
+				// Insert if d is smaller then max
 				emap.insert(std::make_pair(d, e));
-				// erase the old max value
+				// Erase the old max value
 				emap.erase(max);
 			}
 		}
-
 	}
 
 	void KClosestNodesSearch::pack(PackedNodeContainer* cnt)

--- a/src/dht/kclosestnodessearch.h
+++ b/src/dht/kclosestnodessearch.h
@@ -58,10 +58,14 @@ namespace dht
 		CItr begin() const {return emap.begin();}
 		CItr end() const {return emap.end();}
 
-		// Get the target key of the search3
+		/**
+		 * Get the target key of the search3
+		 */
 		const dht::Key & getSearchTarget() const {return key;}
 
-		// Get the number of entries.
+		/**
+		 * Get the number of entries.
+		 */
 		bt::Uint32 getNumEntries() const {return emap.size();}
 
 		/**

--- a/src/dht/kclosestnodessearch.h
+++ b/src/dht/kclosestnodessearch.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTKCLOSESTNODESSEARCH_H
 #define DHTKCLOSESTNODESSEARCH_H
@@ -58,10 +58,10 @@ namespace dht
 		CItr begin() const {return emap.begin();}
 		CItr end() const {return emap.end();}
 
-		/// Get the target key of the search3
+		// Get the target key of the search3
 		const dht::Key & getSearchTarget() const {return key;}
 
-		/// Get the number of entries.
+		// Get the number of entries.
 		bt::Uint32 getNumEntries() const {return emap.size();}
 
 		/**
@@ -79,4 +79,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTKCLOSESTNODESSEARCH_H

--- a/src/dht/key.cpp
+++ b/src/dht/key.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "key.h"
 #include <time.h>
@@ -29,7 +29,8 @@ namespace dht
 {
 
 	Key::Key()
-	{}
+	{
+	}
 
 	Key::Key(const bt::SHA1Hash & k) : bt::SHA1Hash(k)
 	{
@@ -46,7 +47,8 @@ namespace dht
 	}
 
 	Key::~Key()
-	{}
+	{
+	}
 
 	bool Key::operator == (const Key & other) const
 	{
@@ -91,7 +93,7 @@ namespace dht
 	{
 		return operator > (other) || operator == (other);
 	}
-	
+
 	Key operator + (const dht::Key& a, const dht::Key& b)
 	{
 		bt::Uint8 result[20];
@@ -112,10 +114,10 @@ namespace dht
 				carry = false;
 			}
 		}
-		
+
 		return dht::Key(result);
 	}
-	
+
 	Key operator + (const Key & a, bt::Uint8 value)
 	{
 		bt::Uint8 b[20];
@@ -128,17 +130,16 @@ namespace dht
 	{
 		bt::Uint8 result[20];
 		bt::Uint8 remainder = 0;
-		
+
 		for (int i = 0; i < 20; i++)
 		{
 			bt::Uint8 d = (hash[i] + (remainder << 8)) / value;
 			remainder = (hash[i] + (remainder << 8)) % value;
 			result[i] = d;
 		}
-		
+
 		return dht::Key(result);
 	}
-
 
 	Key Key::distance(const Key & a, const Key & b)
 	{
@@ -189,7 +190,7 @@ namespace dht
 				carry = true;
 			}
 		}
-		
+
 		return dht::Key(result);
 	}
 
@@ -200,7 +201,7 @@ namespace dht
 		else
 			return b + (a - b) / 2;
 	}
-	
+
 	Key Key::max()
 	{
 		bt::Uint8 result[20];
@@ -214,6 +215,5 @@ namespace dht
 		std::fill(result, result + 20, 0x0);
 		return Key(result);
 	}
-
 
 }

--- a/src/dht/key.h
+++ b/src/dht/key.h
@@ -61,7 +61,9 @@ namespace dht
 		 */
 		Key(const bt::Uint8* d);
 
-		// Destructor.
+		/**
+		 * Destructor.
+		 */
 		virtual ~Key();
 
 		/**
@@ -70,10 +72,14 @@ namespace dht
 		 */
 		static Key random();
 
-		// Get the minimum key (all zeros)
+		/**
+		 * Get the minimum key (all zeros)
+		 */
 		static Key min();
 
-		// Get the maximum key (all FF)
+		/**
+		 * Get the maximum key (all FF)
+		 */
 		static Key max();
 
 		/**

--- a/src/dht/key.h
+++ b/src/dht/key.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTKEY_H
 #define DHTKEY_H
@@ -23,7 +23,6 @@
 #include <QByteArray>
 #include <util/sha1hash.h>
 #include <ktorrent_export.h>
-
 
 namespace dht
 {
@@ -62,7 +61,7 @@ namespace dht
 		 */
 		Key(const bt::Uint8* d);
 
-		/// Destructor.
+		// Destructor.
 		virtual ~Key();
 
 		/**
@@ -70,11 +69,11 @@ namespace dht
 		 * @return A random Key
 		 */
 		static Key random();
-		
-		/// Get the minimum key (all zeros)
+
+		// Get the minimum key (all zeros)
 		static Key min();
-		
-		/// Get the maximum key (all FF)
+
+		// Get the maximum key (all FF)
 		static Key max();
 
 		/**
@@ -98,14 +97,12 @@ namespace dht
 		 */
 		bool operator < (const Key & other) const;
 
-
 		/**
 		 * Smaller then or equal operator.
 		 * @param other The key to compare
 		 * @return rue if this key is smaller then or equal to other
 		 */
 		bool operator <= (const Key & other) const;
-
 
 		/**
 		 * Greater then operator.
@@ -120,26 +117,26 @@ namespace dht
 		 * @return rue if this key is greater then or equal to other
 		 */
 		bool operator >= (const Key & other) const;
-		
+
 		/**
 		 * Divide by a number operator
 		 */
 		Key operator / (int value) const;
-		
+
 		/**
 		 * Addition for keys
 		 * @param a The first key
 		 * @param b The second key
 		 */
 		friend KTORRENT_EXPORT Key operator + (const Key & a, const Key & b);
-		
+
 		/**
 		 * Subtraction for keys
 		 * @param a The first key
 		 * @param b The second key
 		 */
 		friend KTORRENT_EXPORT Key operator - (const Key & a, const Key & b);
-		
+
 		/**
 		 * Addition for key and a value
 		 * @param a The key
@@ -166,4 +163,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTKEY_H

--- a/src/dht/node.cpp
+++ b/src/dht/node.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,10 +15,9 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "node.h"
-
 #include <util/log.h>
 #include <util/file.h>
 #include <util/error.h>
@@ -34,9 +33,7 @@
 #include "nodelookup.h"
 #include "kbuckettable.h"
 
-
 using namespace bt;
-
 
 namespace dht
 {
@@ -49,11 +46,11 @@ namespace dht
 			num_receives = 0;
 			new_key = false;
 		}
-		
+
 		~Private()
 		{
 		}
-		
+
 		void saveKey(const dht::Key & key, const QString & key_file)
 		{
 			bt::File fptr;
@@ -62,11 +59,11 @@ namespace dht
 				Out(SYS_DHT | LOG_IMPORTANT) << "DHT: Cannot open file " << key_file << " : " << fptr.errorString() << endl;
 				return;
 			}
-			
+
 			fptr.write(key.getData(), 20);
 			fptr.close();
 		}
-		
+
 		dht::Key loadKey(const QString & key_file)
 		{
 			bt::File fptr;
@@ -78,7 +75,7 @@ namespace dht
 				new_key = true;
 				return r;
 			}
-			
+
 			Uint8 data[20];
 			if (fptr.read(data, 20) != 20)
 			{
@@ -87,18 +84,17 @@ namespace dht
 				new_key = true;
 				return r;
 			}
-			
+
 			new_key = false;
 			return dht::Key(data);
 		}
-		
+
 		QScopedPointer<KBucketTable> ipv4_table;
 		QScopedPointer<KBucketTable> ipv6_table;
 		RPCServer* srv;
 		Uint32 num_receives;
 		bool new_key;
 	};
-
 
 	Node::Node(RPCServer* srv, const QString & key_file) :
 			d(new Private(srv))
@@ -120,21 +116,21 @@ namespace dht
 			d->ipv4_table->insert(KBucketEntry(msg.getOrigin(), msg.getID()), d->srv);
 		else
 			d->ipv6_table->insert(KBucketEntry(msg.getOrigin(), msg.getID()), d->srv);
-		
+
 		d->num_receives++;
 
 		/**
 		 * @author Fonic <https://github.com/fonic>
 		 * This used to be 'if (d->num_receives == 3)' which doesn't make much
-         * sense since connecting to / bootstrapping DHT is possible with only
-         * one known node. Also, there seems to be no clue regarding the need
-         * for three known nodes in the DHT specification. Thus, changing this
-         * to 1 so that bootstrapping from one well-known node works.
+		 * sense since connecting to / bootstrapping DHT is possible with only
+		 * one known node. Also, there seems to be no clue regarding the need
+		 * for three known nodes in the DHT specification. Thus, changing this
+		 * to 1 so that bootstrapping from one well-known node works.
 		 */
 		if (d->num_receives == 1)
 		{
-			// do a node lookup upon our own id
-			// when we insert the first entry in the table
+			// Do a node lookup upon our own id when we insert the first entry
+			// in the table
 			dh_table->findOwnNode();
 		}
 
@@ -195,4 +191,5 @@ namespace dht
             num_entries = d->ipv4_table->numEntries() + d->ipv6_table->numEntries();
 		}
 	}
+
 }

--- a/src/dht/node.h
+++ b/src/dht/node.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTNODE_H
 #define DHTNODE_H
@@ -23,7 +23,6 @@
 #include <qobject.h>
 #include "key.h"
 #include "kbucket.h"
-
 
 using bt::Uint8;
 
@@ -33,12 +32,11 @@ namespace dht
 	class RPCMsg;
 	class RPCServer;
 	class KClosestNodesSearch;
-	
-	
+
 	const bt::Uint32 WANT_IPV4 = 1;
 	const bt::Uint32 WANT_IPV6 = 2;
 	const bt::Uint32 WANT_BOTH = WANT_IPV4 | WANT_IPV6;
-	
+
 	/**
 	 * @author Joris Guisson
 	 *
@@ -46,7 +44,7 @@ namespace dht
 	 * our id and 160 KBucket's.
 	 * A KBucketEntry is in node i, when the difference between our id and
 	 * the KBucketEntry's id is between 2 to the power i and 2 to the power i+1.
-	*/
+	 */
 	class Node : public QObject
 	{
 		Q_OBJECT
@@ -63,7 +61,7 @@ namespace dht
 		 */
 		void received(DHT* dh_table, const RPCMsg & msg);
 
-		/// Get our own ID
+		// Get our own ID
 		const dht::Key & getOurID() const {return our_id;}
 
 		/**
@@ -76,21 +74,21 @@ namespace dht
 
 		/**
 		 * Increase the failed queries count of the bucket entry we sent the message to
-		*/
+		 */
 		void onTimeout(RPCMsg::Ptr msg);
 
-		/// Check if a buckets needs to be refreshed, and refresh if necesarry
+		// Check if a buckets needs to be refreshed, and refresh if necesarry
 		void refreshBuckets(DHT* dh_table);
 
-		/// Save the routing table to a file
+		// Save the routing table to a file
 		void saveTable(const QString & file);
 
-		/// Load the routing table from a file
+		// Load the routing table from a file
 		void loadTable(const QString & file);
 
-		/// Get the number of entries in the routing table
+		// Get the number of entries in the routing table
 		bt::Uint32 getNumEntriesInRoutingTable() const {return num_entries;}
-		
+
 	private:
 		class Private;
 		Private* d;
@@ -100,4 +98,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTNODE_H

--- a/src/dht/node.h
+++ b/src/dht/node.h
@@ -61,7 +61,9 @@ namespace dht
 		 */
 		void received(DHT* dh_table, const RPCMsg & msg);
 
-		// Get our own ID
+		/**
+		 * Get our own ID
+		 */
 		const dht::Key & getOurID() const {return our_id;}
 
 		/**
@@ -77,16 +79,24 @@ namespace dht
 		 */
 		void onTimeout(RPCMsg::Ptr msg);
 
-		// Check if a buckets needs to be refreshed, and refresh if necesarry
+		/**
+		 * Check if a buckets needs to be refreshed, and refresh if necessary
+		 */
 		void refreshBuckets(DHT* dh_table);
 
-		// Save the routing table to a file
+		/**
+		 * Save the routing table to a file
+		 */
 		void saveTable(const QString & file);
 
-		// Load the routing table from a file
+		/**
+		 * Load the routing table from a file
+		 */
 		void loadTable(const QString & file);
 
-		// Get the number of entries in the routing table
+		/**
+		 * Get the number of entries in the routing table
+		 */
 		bt::Uint32 getNumEntriesInRoutingTable() const {return num_entries;}
 
 	private:

--- a/src/dht/nodelookup.cpp
+++ b/src/dht/nodelookup.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "nodelookup.h"
 #include <util/log.h>
@@ -39,9 +39,9 @@ namespace dht
 	{
 	}
 
-
 	NodeLookup::~NodeLookup()
-	{}
+	{
+	}
 
 	void NodeLookup::handleNodes(const QByteArray& nodes, int ip_version)
 	{
@@ -49,21 +49,20 @@ namespace dht
 		Uint32 nnodes = nodes.size() / address_size;
 		for (Uint32 j = 0;j < nnodes;j++)
 		{
-			// unpack an entry and add it to the todo list
+			// Unpack an entry and add it to the todo list
 			try
 			{
 				KBucketEntry e = UnpackBucketEntry(nodes, j * address_size, ip_version);
-				// lets not talk to ourself
+				// Let's not talk to ourself
 				if (e.getID() != node->getOurID() && !todo.contains(e) && !visited.contains(e))
 					todo.insert(e);
 			}
 			catch (...)
 			{
-				// bad data, just ignore it
+				// Bad data, just ignore it
 			}
 		}
 	}
-
 
 	void NodeLookup::callFinished(RPCCall* , RPCMsg::Ptr rsp)
 	{
@@ -71,7 +70,7 @@ namespace dht
 		if (isFinished())
 			return;
 
-		// check the response and see if it is a good one
+		// Check the response and see if it is a good one
 		if (rsp->getMethod() == dht::FIND_NODE && rsp->getType() == dht::RSP_MSG)
 		{
 			FindNodeRsp::Ptr fnr = rsp.dynamicCast<FindNodeRsp>();
@@ -91,28 +90,29 @@ namespace dht
 
 	void NodeLookup::callTimeout(RPCCall*)
 	{
-		//	Out(SYS_DHT|LOG_DEBUG) << "NodeLookup::callTimeout" << endl;
+		//Out(SYS_DHT|LOG_DEBUG) << "NodeLookup::callTimeout" << endl;
 	}
 
 	void NodeLookup::update()
 	{
-		//	Out(SYS_DHT|LOG_DEBUG) << "NodeLookup::update" << endl;
-		//	Out(SYS_DHT|LOG_DEBUG) << "todo = " << todo.count() << " ; visited = " << visited.count() << endl;
-		// go over the todo list and send find node calls
-		// until we have nothing left
+		//Out(SYS_DHT|LOG_DEBUG) << "NodeLookup::update" << endl;
+		//Out(SYS_DHT|LOG_DEBUG) << "todo = " << todo.count() << " ; visited = " << visited.count() << endl;
+
+		// Go over the todo list and send find node calls until we have
+		// nothing left
 		while (!todo.empty() && canDoRequest())
 		{
 			KBucketEntrySet::iterator itr = todo.begin();
-			// only send a findNode if we haven't allrready visited the node
+			// Only send a findNode if we haven't allrready visited the node
 			if (!visited.contains(*itr))
 			{
-				// send a findNode to the node
+				// Send a findNode to the node
 				RPCMsg::Ptr fnr(new FindNodeReq(node->getOurID(), node_id));
 				fnr->setOrigin(itr->getAddress());
 				rpcCall(fnr);
 				visited.insert(*itr);
 			}
-			// remove the entry from the todo list
+			// Remove the entry from the todo list
 			todo.erase(itr);
 		}
 
@@ -123,9 +123,10 @@ namespace dht
 		}
 		else if (visited.size() > 200)
 		{
-			// don't let the task run forever
+			// Don't let the task run forever
 			Out(SYS_DHT | LOG_NOTICE) << "DHT: NodeLookup done" << endl;
 			done();
 		}
 	}
+
 }

--- a/src/dht/nodelookup.h
+++ b/src/dht/nodelookup.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTNODELOOKUP_H
 #define DHTNODELOOKUP_H
@@ -30,7 +30,7 @@ namespace dht
 
 	/**
 	 * @author Joris Guisson <joris.guisson@gmail.com>
-	 * 
+	 *
 	 * Task to do a node lookup.
 	 */
 	class NodeLookup : public Task
@@ -42,10 +42,10 @@ namespace dht
 		virtual void update();
 		virtual void callFinished(RPCCall* c, RPCMsg::Ptr rsp);
 		virtual void callTimeout(RPCCall* c);
-	
+
 	private:
 		void handleNodes(const QByteArray & nodes, int ip_version);
-		
+
 	private:
 		dht::Key node_id;
 		bt::Uint32 num_nodes_rsp;
@@ -53,4 +53,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTNODELOOKUP_H

--- a/src/dht/pack.cpp
+++ b/src/dht/pack.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "pack.h"
 #include <arpa/inet.h>
@@ -32,62 +32,62 @@ namespace dht
 		const net::Address & addr = e.getAddress();
 		Uint8* data = (Uint8*)ba.data();
 		Uint8* ptr = data + off;
-		
+
 		if (addr.ipVersion() == 4)
 		{
-			// first check size
+			// First check size
 			if ((int) off + 26 > ba.size())
 				throw bt::Error("Not enough room in buffer");
-			
-			// copy ID, IP address and port into the buffer
+
+			// Copy ID, IP address and port into the buffer
 			memcpy(ptr,e.getID().getData(),20);
 			bt::WriteUint32(ptr,20,addr.toIPv4Address());
 			bt::WriteUint16(ptr,24,addr.port());
 		}
 		else
 		{
-			// first check size
+			// First check size
 			if ((int) off + 38 > ba.size())
 				throw bt::Error("Not enough room in buffer");
-			
-			// copy ID, IP address and port into the buffer
+
+			// Copy ID, IP address and port into the buffer
 			memcpy(ptr,e.getID().getData(),20);
 			memcpy(ptr + 20,addr.toIPv6Address().c,16);
 			bt::WriteUint16(ptr,36,addr.port());
 		}
 	}
-	
+
 	KBucketEntry UnpackBucketEntry(const QByteArray & ba,Uint32 off,int ip_version)
 	{
 		if (ip_version == 4)
 		{
 			if ((int) off + 26 > ba.size())
 				throw bt::Error("Not enough room in buffer");
-			
+
 			const Uint8* data = (Uint8*)ba.data();
 			const Uint8* ptr = data + off;
-			
-			// get the port, ip and key);
+
+			// Get the port, ip and key);
 			Uint16 port = bt::ReadUint16(ptr,24);
 			Uint32 ip = bt::ReadUint32(ptr,20);
 			Uint8 key[20];
 			memcpy(key,ptr,20);
-			
+
 			return KBucketEntry(net::Address(ip,port),dht::Key(key));
 		}
 		else
 		{
 			if ((int) off + 38 > ba.size())
 				throw bt::Error("Not enough room in buffer");
-			
+
 			const Uint8* data = (Uint8*)ba.data();
 			const Uint8* ptr = data + off;
-			
-			// get the port, ip and key);
+
+			// Get the port, ip and key);
 			Uint16 port = bt::ReadUint16(ptr,36);
 			Uint8 key[20];
 			memcpy(key,ptr,20);
-			
+
 			return KBucketEntry(net::Address((quint8*)ptr + 20,port),dht::Key(key));
 		}
 	}

--- a/src/dht/pack.h
+++ b/src/dht/pack.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTPACK_H
 #define DHTPACK_H
@@ -46,4 +46,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTPACK_H

--- a/src/dht/packednodecontainer.cpp
+++ b/src/dht/packednodecontainer.cpp
@@ -17,13 +17,18 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "packednodecontainer.h"
 
 namespace dht
 {
-	PackedNodeContainer::PackedNodeContainer() {}
-	PackedNodeContainer::~PackedNodeContainer() {}
+
+	PackedNodeContainer::PackedNodeContainer()
+	{
+	}
+
+	PackedNodeContainer::~PackedNodeContainer()
+	{
+	}
 
 	void PackedNodeContainer::addNode(const QByteArray & a)
 	{
@@ -34,4 +39,3 @@ namespace dht
 	}
 
 }
-

--- a/src/dht/packednodecontainer.h
+++ b/src/dht/packednodecontainer.h
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_PACKEDNODECONTAINER_H
 #define DHT_PACKEDNODECONTAINER_H
 
@@ -36,20 +35,20 @@ namespace dht
 	public:
 		PackedNodeContainer();
 		virtual ~PackedNodeContainer();
-		
-		/// Add a single node to the nodes or nodes2 parameter depending on it's size
+
+		// Add a single node to the nodes or nodes2 parameter depending on it's size
 		void addNode(const QByteArray & a);
-		
-		/// Get the nodes parameter
+
+		// Get the nodes parameter
 		const QByteArray & getNodes() const {return nodes;}
-		
-		/// Get the nodes6 parameter
+
+		// Get the nodes6 parameter
 		const QByteArray & getNodes6() const {return nodes6;}
 	protected:
 		QByteArray nodes;
 		QByteArray nodes6;
 	};
-	
+
 }
 
 #endif // DHT_PACKEDNODECONTAINER_H

--- a/src/dht/packednodecontainer.h
+++ b/src/dht/packednodecontainer.h
@@ -36,13 +36,19 @@ namespace dht
 		PackedNodeContainer();
 		virtual ~PackedNodeContainer();
 
-		// Add a single node to the nodes or nodes2 parameter depending on it's size
+		/**
+		 * Add a single node to the nodes or nodes2 parameter depending on it's size
+		 */
 		void addNode(const QByteArray & a);
 
-		// Get the nodes parameter
+		/**
+		 * Get the nodes parameter
+		 */
 		const QByteArray & getNodes() const {return nodes;}
 
-		// Get the nodes6 parameter
+		/**
+		 * Get the nodes6 parameter
+		 */
 		const QByteArray & getNodes6() const {return nodes6;}
 	protected:
 		QByteArray nodes;

--- a/src/dht/pingreq.cpp
+++ b/src/dht/pingreq.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2012 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "pingreq.h"
 #include <util/log.h>
 #include <bcodec/bencoder.h>
@@ -27,6 +26,7 @@ using namespace bt;
 
 namespace dht
 {
+
 	PingReq::PingReq() : RPCMsg(QByteArray(), PING, REQ_MSG, Key())
 	{
 	}
@@ -36,7 +36,8 @@ namespace dht
 	}
 
 	PingReq::~PingReq()
-	{}
+	{
+	}
 
 	void PingReq::apply(dht::DHT* dh_table)
 	{
@@ -69,5 +70,5 @@ namespace dht
 		}
 		enc.end();
 	}
-}
 
+}

--- a/src/dht/pingreq.h
+++ b/src/dht/pingreq.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2012 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_PINGREQ_H
 #define DHT_PINGREQ_H
 
@@ -35,11 +34,11 @@ namespace dht
 		PingReq();
 		PingReq(const Key & id);
 		virtual ~PingReq();
-		
+
 		virtual void apply(DHT* dh_table);
 		virtual void print();
 		virtual void encode(QByteArray & arr) const;
-		
+
 		typedef QSharedPointer<PingReq> Ptr;
 	};
 

--- a/src/dht/pingrsp.cpp
+++ b/src/dht/pingrsp.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "pingrsp.h"
 #include <util/log.h>
 #include <bcodec/bencoder.h>
@@ -25,20 +24,22 @@
 
 using namespace bt;
 
-
 namespace dht
 {
+
 	PingRsp::PingRsp()
 			: RPCMsg(QByteArray(), PING, RSP_MSG, Key())
 	{
 	}
-	
+
 	PingRsp::PingRsp(const QByteArray & mtid, const Key & id)
 			: RPCMsg(mtid, PING, RSP_MSG, id)
-	{}
+	{
+	}
 
-	PingRsp::~PingRsp() 
-	{}
+	PingRsp::~PingRsp()
+	{
+	}
 
 	void PingRsp::apply(dht::DHT* dh_table)
 	{
@@ -66,5 +67,5 @@ namespace dht
 		}
 		enc.end();
 	}
-}
 
+}

--- a/src/dht/pingrsp.h
+++ b/src/dht/pingrsp.h
@@ -17,10 +17,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_PINGRSP_H
 #define DHT_PINGRSP_H
-
 
 #include "rpcmsg.h"
 
@@ -43,6 +41,7 @@ namespace dht
 
 		typedef QSharedPointer<PingRsp> Ptr;
 	};
+
 }
 
 #endif // DHT_PINGRSP_H

--- a/src/dht/rpccall.cpp
+++ b/src/dht/rpccall.cpp
@@ -36,9 +36,12 @@ namespace dht
 		timer.setSingleShot(true);
 		connect(&timer, &QTimer::timeout, this, &RPCCall::onTimeout);
 		if (!queued)
-			timer.start(30*1000);
+			/**
+			 * @author Fonic <https://github.com/fonic>
+			 * Use constant defined in rpccall.h instead of hard-coded value.
+			 */
+			timer.start(RPC_CALL_TIMEOUT);
 	}
-
 
 	RPCCall::~RPCCall()
 	{
@@ -47,7 +50,11 @@ namespace dht
 	void RPCCall::start()
 	{
 		queued = false;
-		timer.start(30*1000);
+		/**
+		 * @author Fonic <https://github.com/fonic>
+		 * Use constant defined in rpccall.h instead of hard-coded value.
+		 */
+		timer.start(RPC_CALL_TIMEOUT);
 	}
 
 	void RPCCall::onTimeout()

--- a/src/dht/rpccall.cpp
+++ b/src/dht/rpccall.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,17 +15,18 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "rpccall.h"
 #include "dht.h"
 #include "rpcmsg.h"
 
-
 namespace dht
 {
+
 	RPCCallListener::RPCCallListener(QObject* parent) : QObject(parent)
-	{}
+	{
+	}
 
 	RPCCallListener::~RPCCallListener()
 	{

--- a/src/dht/rpccall.h
+++ b/src/dht/rpccall.h
@@ -21,12 +21,23 @@
 #define DHTRPCCALL_H
 
 #include <qtimer.h>
+#include <util/constants.h>
 #include "key.h"
 #include "rpcmsg.h"
 
 namespace dht
 {
 	class RPCCall;
+
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 * Timeout for RPC calls (i.e. DHT requests). This used to be hard-coded
+	 * in rpccall.cpp to a value of 30 * 1000. The reference implementation
+	 * uses much lower timeouts (4 secs, peers taking >= 1 sec to respond are
+	 * flagged as 'slow'), thus the value was lowered. This should probably be
+	 * made user-configurable as an advanced setting.
+	 */
+	const bt::Uint32 RPC_CALL_TIMEOUT = 5 * 1000;
 
 	/**
 	 * Class which objects should derive from, if they want to know the result of a call.

--- a/src/dht/rpccall.h
+++ b/src/dht/rpccall.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTRPCCALL_H
 #define DHTRPCCALL_H
@@ -41,7 +41,7 @@ namespace dht
 
 	/**
 	 * Class which objects should derive from, if they want to know the result of a call.
-	*/
+	 */
 	class RPCCallListener : public QObject
 	{
 		Q_OBJECT
@@ -91,13 +91,13 @@ namespace dht
 		 */
 		void addListener(RPCCallListener* cl);
 
-		/// Get the message type
+		// Get the message type
 		Method getMsgMethod() const;
 
-		/// Get the request sent
+		// Get the request sent
 		const RPCMsg::Ptr getRequest() const {return msg;}
 
-		/// Get the request sent
+		// Get the request sent
 		RPCMsg::Ptr getRequest() {return msg;}
 
 	private slots:
@@ -115,4 +115,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTRPCCALL_H

--- a/src/dht/rpccall.h
+++ b/src/dht/rpccall.h
@@ -91,13 +91,19 @@ namespace dht
 		 */
 		void addListener(RPCCallListener* cl);
 
-		// Get the message type
+		/**
+		 * Get the message type
+		 */
 		Method getMsgMethod() const;
 
-		// Get the request sent
+		/**
+		 * Get the request sent
+		 */
 		const RPCMsg::Ptr getRequest() const {return msg;}
 
-		// Get the request sent
+		/**
+		 * Get the request sent
+		 */
 		RPCMsg::Ptr getRequest() {return msg;}
 
 	private slots:

--- a/src/dht/rpccall.h
+++ b/src/dht/rpccall.h
@@ -34,8 +34,8 @@ namespace dht
 	 * Timeout for RPC calls (i.e. DHT requests). This used to be hard-coded
 	 * in rpccall.cpp to a value of 30 * 1000. The reference implementation
 	 * proposes much lower timeouts (4 secs, peers taking >= 1 sec to respond
-	 * are flagged as 'slow'), thus the value was lowered. This should probably
-	 * be made user-configurable as an advanced setting.
+	 * are flagged as 'slow'), thus the value was lowered considerably. This
+	 * should probably be made user-configurable as an advanced setting.
 	 */
 	const bt::Uint32 RPC_CALL_TIMEOUT = 5 * 1000;
 

--- a/src/dht/rpccall.h
+++ b/src/dht/rpccall.h
@@ -33,9 +33,9 @@ namespace dht
 	 * @author Fonic <https://github.com/fonic>
 	 * Timeout for RPC calls (i.e. DHT requests). This used to be hard-coded
 	 * in rpccall.cpp to a value of 30 * 1000. The reference implementation
-	 * uses much lower timeouts (4 secs, peers taking >= 1 sec to respond are
-	 * flagged as 'slow'), thus the value was lowered. This should probably be
-	 * made user-configurable as an advanced setting.
+	 * proposes much lower timeouts (4 secs, peers taking >= 1 sec to respond
+	 * are flagged as 'slow'), thus the value was lowered. This should probably
+	 * be made user-configurable as an advanced setting.
 	 */
 	const bt::Uint32 RPC_CALL_TIMEOUT = 5 * 1000;
 

--- a/src/dht/rpcmsg.cpp
+++ b/src/dht/rpcmsg.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,14 +15,13 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "rpcmsg.h"
 #include <bcodec/bnode.h>
 #include <util/error.h>
 
 using namespace bt;
-
 
 namespace dht
 {
@@ -33,23 +32,24 @@ namespace dht
 	{
 	}
 
-
 	RPCMsg::RPCMsg(const QByteArray & mtid, Method m, Type type, const Key & id) :
 			mtid(mtid),
 			method(m),
 			type(type),
 			id(id)
-	{}
+	{
+	}
 
 	RPCMsg::~RPCMsg()
-	{}
-	
+	{
+	}
+
 	void RPCMsg::parse(bt::BDictNode* dict)
 	{
 		mtid = dict->getByteArray(TID);
 		if (mtid.isEmpty())
 			throw bt::Error("Invalid DHT transaction ID");
-		
+
 		QString t = dict->getString(TYP, 0);
 		if (t == REQ)
 		{
@@ -57,7 +57,7 @@ namespace dht
 			BDictNode* args = dict->getDict(ARG);
 			if (!args)
 				return;
-			
+
 			id = Key(args->getByteArray("id"));
 		}
 		else if (t == RSP)
@@ -66,7 +66,7 @@ namespace dht
 			BDictNode* args = dict->getDict(RSP);
 			if (!args)
 				return;
-			
+
 			id = Key(args->getByteArray("id"));
 		}
 		else if (t == ERR_DHT)
@@ -74,4 +74,5 @@ namespace dht
 		else
 			throw bt::Error(QString("Unknown message type %1").arg(t));
 	}
+
 }

--- a/src/dht/rpcmsg.h
+++ b/src/dht/rpcmsg.h
@@ -97,31 +97,49 @@ namespace dht
 		 */
 		virtual void parse(bt::BDictNode* dict);
 
-		// Set the origin (i.e. where the message came from)
+		/**
+		 * Set the origin (i.e. where the message came from)
+		 */
 		void setOrigin(const net::Address & o) {origin = o;}
 
-		// Get the origin
+		/**
+		 * Get the origin
+		 */
 		const net::Address & getOrigin() const {return origin;}
 
-		// Set the origin (i.e. where the message came from)
+		/**
+		 * Set the origin (i.e. where the message came from)
+		 */
 		void setDestination(const net::Address & o) {origin = o;}
 
-		// Get the origin
+		/**
+		 * Get the origin
+		 */
 		const net::Address & getDestination() const {return origin;}
 
-		// Get the MTID
+		/**
+		 * Get the MTID
+		 */
 		const QByteArray & getMTID() const {return mtid;}
 
-		// Set the MTID
+		/**
+		 * Set the MTID
+		 */
 		void setMTID(const QByteArray & m) {mtid = m;}
 
-		// Get the id of the sender
+		/**
+		 * Get the id of the sender
+		 */
 		const Key & getID() const {return id;}
 
-		// Get the type of the message
+		/**
+		 * Get the type of the message
+		 */
 		Type getType() const {return type;}
 
-		// Get the message it's method
+		/**
+		 * Get the method of the message
+		 */
 		Method getMethod() const {return method;}
 
 	protected:

--- a/src/dht/rpcmsg.h
+++ b/src/dht/rpcmsg.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTRPCMSG_H
 #define DHTRPCMSG_H
@@ -62,7 +62,7 @@ namespace dht
 
 	/**
 	 * Base class for all RPC messages.
-	*/
+	 */
 	class KTORRENT_EXPORT RPCMsg
 	{
 	public:
@@ -94,34 +94,34 @@ namespace dht
 		 * Parse the message
 		 * @param dict Data dictionary
 		 * @throws bt::Error when something goes wrong
-		 **/
+		 */
 		virtual void parse(bt::BDictNode* dict);
 
-		/// Set the origin (i.e. where the message came from)
+		// Set the origin (i.e. where the message came from)
 		void setOrigin(const net::Address & o) {origin = o;}
 
-		/// Get the origin
+		// Get the origin
 		const net::Address & getOrigin() const {return origin;}
 
-		/// Set the origin (i.e. where the message came from)
+		// Set the origin (i.e. where the message came from)
 		void setDestination(const net::Address & o) {origin = o;}
 
-		/// Get the origin
+		// Get the origin
 		const net::Address & getDestination() const {return origin;}
 
-		/// Get the MTID
+		// Get the MTID
 		const QByteArray & getMTID() const {return mtid;}
 
-		/// Set the MTID
+		// Set the MTID
 		void setMTID(const QByteArray & m) {mtid = m;}
 
-		/// Get the id of the sender
+		// Get the id of the sender
 		const Key & getID() const {return id;}
 
-		/// Get the type of the message
+		// Get the type of the message
 		Type getType() const {return type;}
 
-		/// Get the message it's method
+		// Get the message it's method
 		Method getMethod() const {return method;}
 
 	protected:
@@ -132,7 +132,6 @@ namespace dht
 		net::Address origin;
 	};
 
-
 }
 
-#endif
+#endif // DHTRPCMSG_H

--- a/src/dht/rpcmsgfactory.cpp
+++ b/src/dht/rpcmsgfactory.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "rpcmsgfactory.h"
 #include <util/log.h>
 #include <util/error.h>
@@ -41,20 +40,18 @@ namespace dht
 
 	RPCMsgFactory::RPCMsgFactory()
 	{
-
 	}
 
 	RPCMsgFactory::~RPCMsgFactory()
 	{
-
 	}
-	
+
 	RPCMsg::Ptr RPCMsgFactory::buildRequest(BDictNode* dict)
 	{
 		BDictNode* args = dict->getDict(ARG);
 		if (!args)
 			throw bt::Error("Invalid request, arguments missing");
-		
+
 		RPCMsg::Ptr msg;
 		QString str = dict->getString(REQ, 0);
 		if (str == "ping")
@@ -89,22 +86,20 @@ namespace dht
 		else
 			throw bt::Error(QString("Invalid request type %1").arg(str));
 	}
-	
 
 	RPCMsg::Ptr RPCMsgFactory::buildResponse(BDictNode* dict, dht::RPCMethodResolver* method_resolver)
 	{
 		BDictNode* args = dict->getDict(RSP);
 		if (!args)
 			throw bt::Error("Arguments missing for DHT response");
-		
+
 		QByteArray mtid = dict->getByteArray(TID);
-		// check for empty byte arrays should prevent 144416
+		// Check for empty byte arrays should prevent 144416
 		if (mtid.size() == 0)
 			throw bt::Error("Empty transaction ID in DHT response");
-		
+
+		// Find the call
 		RPCMsg::Ptr msg;
-		
-		// find the call
 		Method method = method_resolver->findMethod(mtid);
 		switch (method)
 		{
@@ -128,10 +123,9 @@ namespace dht
 			default:
 				throw bt::Error(QString("Unknown DHT rpc call (transaction id = %1)").arg(mtid[0]));
 		}
-		
+
 		return msg;
 	}
-
 
 	RPCMsg::Ptr RPCMsgFactory::build(bt::BDictNode* dict, RPCMethodResolver* method_resolver)
 	{

--- a/src/dht/rpcmsgfactory.h
+++ b/src/dht/rpcmsgfactory.h
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_RPCMSGFACTORY_H
 #define DHT_RPCMSGFACTORY_H
 
@@ -33,9 +32,9 @@ namespace dht
 	{
 	public:
 		virtual ~RPCMethodResolver() {}
-		
-		/// Return the method associated with an mtid
-		virtual Method findMethod(const QByteArray & mtid) = 0; 
+
+		// Return the method associated with an mtid
+		virtual Method findMethod(const QByteArray & mtid) = 0;
 	};
 
 	/**
@@ -51,11 +50,11 @@ namespace dht
 		 * Creates a message out of a BDictNode.
 		 * @param dict The BDictNode
 		 * @param srv The RPCMethodResolver
-		 * @return A newly created message 
+		 * @return A newly created message
 		 * @throw bt::Error if something goes wrong
 		 */
 		RPCMsg::Ptr build(bt::BDictNode* dict, RPCMethodResolver* method_resolver);
-		
+
 	private:
 		RPCMsg::Ptr buildRequest(bt::BDictNode* dict);
 		RPCMsg::Ptr buildResponse(bt::BDictNode* dict, RPCMethodResolver* method_resolver);

--- a/src/dht/rpcmsgfactory.h
+++ b/src/dht/rpcmsgfactory.h
@@ -33,7 +33,9 @@ namespace dht
 	public:
 		virtual ~RPCMethodResolver() {}
 
-		// Return the method associated with an mtid
+		/**
+		 * Return the method associated with an mtid
+		 */
 		virtual Method findMethod(const QByteArray & mtid) = 0;
 	};
 

--- a/src/dht/rpcserver.cpp
+++ b/src/dht/rpcserver.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "rpcserver.h"
 #include <QHostAddress>
@@ -50,7 +50,8 @@ namespace dht
 	public:
 		Private(RPCServer* p, DHT* dh_table, Uint16 port)
 				: p(p), dh_table(dh_table), next_mtid(0), port(port)
-		{}
+		{
+		}
 
 		~Private()
 		{
@@ -86,14 +87,14 @@ namespace dht
 		{
 			try
 			{
-				// read and decode the packet
+				// Read and decode the packet
 				BDecoder bdec(ptr->get(), ptr->size(), false);
 				boost::scoped_ptr<BNode> n(bdec.decode());
 
 				if (!n || n->getType() != BNode::DICT)
 					return;
 
-				// try to make a RPCMsg of it
+				// Try to make a RPCMsg of it
 				RPCMsg::Ptr msg = factory.build((BDictNode*)n.get(), this);
 				if (msg)
 				{
@@ -101,12 +102,12 @@ namespace dht
 						msg->setOrigin(addr.convertIPv4Mapped());
 					else
 						msg->setOrigin(addr);
-					
+
 					msg->apply(dh_table);
-					// erase an existing call
+					// Erase an existing call
 					if (msg->getType() == RSP_MSG && calls.contains(msg->getMTID()))
 					{
-						// delete the call, but first notify it off the response
+						// Delete the call, but first notify it off the response
 						RPCCall* c = calls.find(msg->getMTID());
 						c->response(msg);
 						calls.erase(msg->getMTID());
@@ -125,7 +126,7 @@ namespace dht
 		{
 			Q_UNUSED(sock);
 		}
-		
+
 		virtual Method findMethod(const QByteArray& mtid)
 		{
 			const RPCCall* call = calls.find(mtid);
@@ -168,13 +169,13 @@ namespace dht
 		{
 			Uint8 start = next_mtid;
 			QByteArray mtid(1, start);
-			
+
 			while (calls.contains(mtid))
 			{
 				mtid[0] = ++next_mtid;
-				if (next_mtid == start) // if this happens we cannot do any calls
+				if (next_mtid == start) // If this happens we cannot do any calls
 				{
-					// so queue the call
+					// So queue the call
 					RPCCall* c = new RPCCall(msg, true);
 					call_queue.append(c);
 					Out(SYS_DHT | LOG_NOTICE) << "Queueing RPC call, no slots available at the moment" << endl;
@@ -194,12 +195,12 @@ namespace dht
 			QByteArray data;
 			msg->encode(data);
 			send(msg->getDestination(), data);
-			//	PrintRawData(data);
+			//PrintRawData(data);
 		}
 
 		void timedOut(const QByteArray & mtid)
 		{
-			// delete the call
+			// Delete the call
 			RPCCall* c = calls.find(mtid);
 			if (c)
 			{
@@ -220,13 +221,10 @@ namespace dht
 		RPCMsgFactory factory;
 	};
 
-
-
 	RPCServer::RPCServer(DHT* dh_table, Uint16 port, QObject *parent)
 			: QObject(parent), d(new Private(this, dh_table, port))
 	{
 	}
-
 
 	RPCServer::~RPCServer()
 	{
@@ -260,8 +258,7 @@ namespace dht
 		d->reset();
 	}
 
-#if 0
-	static void PrintRawData(const QByteArray & data)
+	/*static void PrintRawData(const QByteArray & data)
 	{
 		QString tmp;
 		for (int i = 0;i < data.size();i++)
@@ -274,15 +271,14 @@ namespace dht
 		}
 
 		Out(SYS_DHT | LOG_DEBUG) << tmp << endl;
-	}
-#endif
+	}*/
 
 	RPCCall* RPCServer::doCall(RPCMsg::Ptr msg)
 	{
 		RPCCall* c = d->doCall(msg);
 		if (c)
 			connect(c, &RPCCall::timeout, this, &RPCServer::callTimeout);
-		
+
 		return c;
 	}
 
@@ -297,7 +293,7 @@ namespace dht
 		msg.encode(data);
 		d->send(msg.getDestination(), data);
 	}
-	
+
 	void RPCServer::callTimeout(RPCCall* call)
 	{
 		d->timedOut(call->getRequest()->getMTID());
@@ -314,5 +310,5 @@ namespace dht
 	{
 		return d->calls.count();
 	}
-}
 
+}

--- a/src/dht/rpcserver.h
+++ b/src/dht/rpcserver.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTRPCSERVER_H
 #define DHTRPCSERVER_H
@@ -49,14 +49,14 @@ namespace dht
 		RPCServer(DHT* dh_table, Uint16 port, QObject *parent = 0);
 		virtual ~RPCServer();
 
-		/// Start the server
+		// Start the server
 		void start();
 
-		/// Stop the server
+		// Stop the server
 		void stop();
 
 		/**
-		 * Do a RPC call.
+		 * Do an RPC call.
 		 * @param msg The message to send
 		 * @return The call object
 		 */
@@ -82,9 +82,9 @@ namespace dht
 		 */
 		void ping(const dht::Key & our_id, const net::Address & addr);
 
-		/// Get the number of active calls
+		// Get the number of active calls
 		Uint32 getNumActiveRPCCalls() const;
-		
+
 	private slots:
 		void callTimeout(RPCCall* call);
 
@@ -95,4 +95,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTRPCSERVER_H

--- a/src/dht/rpcserver.h
+++ b/src/dht/rpcserver.h
@@ -49,10 +49,14 @@ namespace dht
 		RPCServer(DHT* dh_table, Uint16 port, QObject *parent = 0);
 		virtual ~RPCServer();
 
-		// Start the server
+		/**
+		 * Start the server
+		 */
 		void start();
 
-		// Stop the server
+		/**
+		 * Stop the server
+		 */
 		void stop();
 
 		/**
@@ -82,7 +86,9 @@ namespace dht
 		 */
 		void ping(const dht::Key & our_id, const net::Address & addr);
 
-		// Get the number of active calls
+		/**
+		 * Get the number of active calls
+		 */
 		Uint32 getNumActiveRPCCalls() const;
 
 	private slots:

--- a/src/dht/rpcserverinterface.cpp
+++ b/src/dht/rpcserverinterface.cpp
@@ -17,18 +17,17 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include "rpcserverinterface.h"
 
 namespace dht
 {
+
 	RPCServerInterface::RPCServerInterface()
 	{
-
 	}
 
 	RPCServerInterface::~RPCServerInterface()
 	{
-
 	}
+
 }

--- a/src/dht/rpcserverinterface.h
+++ b/src/dht/rpcserverinterface.h
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #ifndef DHT_RPCSERVERINTERFACE_H
 #define DHT_RPCSERVERINTERFACE_H
 
@@ -35,9 +34,9 @@ namespace dht
 	public:
 		RPCServerInterface();
 		virtual ~RPCServerInterface();
-		
+
 		/**
-		 * Do a RPC call.
+		 * Do an RPC call.
 		 * @param msg The message to send
 		 * @return The call object
 		 */

--- a/src/dht/task.cpp
+++ b/src/dht/task.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,14 +15,12 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "task.h"
 #include <net/addressresolver.h>
 #include "kclosestnodessearch.h"
 #include "rpcserver.h"
-
-
 
 namespace dht
 {
@@ -35,9 +33,7 @@ namespace dht
 			task_finished(false),
 			queued(true)
 	{
-
 	}
-
 
 	Task::~Task()
 	{
@@ -45,7 +41,7 @@ namespace dht
 
 	void Task::start(const KClosestNodesSearch & kns, bool queued)
 	{
-		// fill the todo list
+		// Fill the todo list
 		for (KClosestNodesSearch::CItr i = kns.begin(); i != kns.end();i++)
 			todo.insert(i->second);
 		this->queued = queued;
@@ -61,7 +57,6 @@ namespace dht
 			update();
 		}
 	}
-
 
 	void Task::onResponse(dht::RPCCall* c, dht::RPCMsg::Ptr rsp)
 	{
@@ -140,4 +135,3 @@ namespace dht
 	}
 
 }
-

--- a/src/dht/task.h
+++ b/src/dht/task.h
@@ -35,6 +35,14 @@ namespace dht
 	class Task;
 	class KClosestNodesSearch;
 
+	/**
+	 * @author Fonic <https://github.com/fonic>
+	 *
+	 * Maximum number of concurrent requests. A value of 16 is proposed by the
+	 * reference implementation. Since this greatly influences the time it takes
+	 * the client to 'get to know' the DHT network, this should probably be made
+	 * user-configurable as an advanced setting.
+	 */
 	const bt::Uint32 MAX_CONCURRENT_REQS = 16;
 
 	/**

--- a/src/dht/task.h
+++ b/src/dht/task.h
@@ -73,14 +73,18 @@ namespace dht
 		void start(const KClosestNodesSearch & kns, bool queued);
 
 		/**
-		 *  Start the task, to be used when a task is queued.
+		 * Start the task, to be used when a task is queued.
 		 */
 		void start();
 
-		// Decrements the outstanding_reqs
+		/**
+		 * Decrements the outstanding_reqs
+		 */
 		virtual void onResponse(RPCCall* c, RPCMsg::Ptr rsp);
 
-		// Decrements the outstanding_reqs
+		/**
+		 * Decrements the outstanding_reqs
+		 */
 		virtual void onTimeout(RPCCall* c);
 
 		/**
@@ -109,13 +113,19 @@ namespace dht
 		 */
 		bool rpcCall(RPCMsg::Ptr req);
 
-		// See if we can do a request
+		/**
+		 * See if we can do a request
+		 */
 		bool canDoRequest() const {return outstanding_reqs < MAX_CONCURRENT_REQS;}
 
-		// Is the task finished
+		/**
+		 * Is the task finished
+		 */
 		bool isFinished() const {return task_finished;}
 
-		// Get the number of outstanding requests
+		/**
+		 * Get the number of outstanding requests
+		 */
 		bt::Uint32 getNumOutstandingRequests() const {return outstanding_reqs;}
 
 		bool isQueued() const {return queued;}
@@ -125,7 +135,9 @@ namespace dht
 		 */
 		void emitDataReady();
 
-		// Kills the task
+		/**
+		 * Kills the task
+		 */
 		void kill();
 
 		/**

--- a/src/dht/task.h
+++ b/src/dht/task.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTTASK_H
 #define DHTTASK_H
@@ -72,16 +72,15 @@ namespace dht
 		 */
 		void start(const KClosestNodesSearch & kns, bool queued);
 
-
 		/**
 		 *  Start the task, to be used when a task is queued.
 		 */
 		void start();
 
-		/// Decrements the outstanding_reqs
+		// Decrements the outstanding_reqs
 		virtual void onResponse(RPCCall* c, RPCMsg::Ptr rsp);
 
-		/// Decrements the outstanding_reqs
+		// Decrements the outstanding_reqs
 		virtual void onTimeout(RPCCall* c);
 
 		/**
@@ -110,13 +109,13 @@ namespace dht
 		 */
 		bool rpcCall(RPCMsg::Ptr req);
 
-		/// See if we can do a request
+		// See if we can do a request
 		bool canDoRequest() const {return outstanding_reqs < MAX_CONCURRENT_REQS;}
 
-		/// Is the task finished
+		// Is the task finished
 		bool isFinished() const {return task_finished;}
 
-		/// Get the number of outstanding requests
+		// Get the number of outstanding requests
 		bt::Uint32 getNumOutstandingRequests() const {return outstanding_reqs;}
 
 		bool isQueued() const {return queued;}
@@ -126,7 +125,7 @@ namespace dht
 		 */
 		void emitDataReady();
 
-		/// Kills the task
+		// Kills the task
 		void kill();
 
 		/**
@@ -157,8 +156,8 @@ namespace dht
 		void onResolverResults(net::AddressResolver* res);
 
 	protected:
-		dht::KBucketEntrySet visited; // nodes visited
-		dht::KBucketEntrySet todo; // nodes todo
+		dht::KBucketEntrySet visited; // Nodes visited
+		dht::KBucketEntrySet todo;    // Nodes todo
 		Node* node;
 
 	private:
@@ -170,6 +169,4 @@ namespace dht
 
 }
 
-#endif
-
-
+#endif // DHTTASK_H

--- a/src/dht/taskmanager.cpp
+++ b/src/dht/taskmanager.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #include "taskmanager.h"
 #include <QtAlgorithms>
@@ -32,11 +32,9 @@ namespace dht
 	{
 	}
 
-
 	TaskManager::~TaskManager()
 	{
 	}
-
 
 	void TaskManager::addTask(Task* task)
 	{

--- a/src/dht/taskmanager.h
+++ b/src/dht/taskmanager.h
@@ -47,10 +47,14 @@ namespace dht
 		 */
 		void addTask(Task* task);
 
-		// Get the number of running tasks
+		/**
+		 * Get the number of running tasks
+		 */
 		bt::Uint32 getNumTasks() const {return num_active;}
 
-		// Get the number of queued tasks
+		/**
+		 * Get the number of queued tasks
+		 */
 		bt::Uint32 getNumQueuedTasks() const {return queued.count();}
 
 	private slots:

--- a/src/dht/taskmanager.h
+++ b/src/dht/taskmanager.h
@@ -1,6 +1,6 @@
 /***************************************************************************
- *   Copyright (C) 2005 by Joris Guisson                                   *
- *   joris.guisson@gmail.com                                               *
+ *   Copyright (C) 2012 by                                                 *
+ *   Joris Guisson <joris.guisson@gmail.com>                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -15,7 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.             *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
 #ifndef DHTTASKMANAGER_H
 #define DHTTASKMANAGER_H
@@ -31,28 +31,28 @@ namespace dht
 
 	/**
 	 * @author Joris Guisson <joris.guisson@gmail.com>
-	 * 
+	 *
 	 * Manages all dht tasks.
-	*/
+	 */
 	class TaskManager : public QObject
 	{
 		Q_OBJECT
 	public:
 		TaskManager(const DHT* dh_table);
 		virtual ~TaskManager();
-		
+
 		/**
 		 * Add a task to manage.
-		 * @param task 
+		 * @param task
 		 */
 		void addTask(Task* task);
-		
-		/// Get the number of running tasks
+
+		// Get the number of running tasks
 		bt::Uint32 getNumTasks() const {return num_active;}
-		
-		/// Get the number of queued tasks
+
+		// Get the number of queued tasks
 		bt::Uint32 getNumQueuedTasks() const {return queued.count();}
-		
+
 	private slots:
 		void taskFinished(Task* task);
 
@@ -64,4 +64,4 @@ namespace dht
 
 }
 
-#endif
+#endif // DHTTASKMANAGER_H

--- a/src/dht/tests/keytest.cpp
+++ b/src/dht/tests/keytest.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include <algorithm>
 #include <QtTest>
 #include <QString>
@@ -43,20 +42,20 @@ static dht::Key KeyFromHexString(const QString & str)
 {
 	bt::Uint8 result[20];
 	std::fill(result, result + 20, 0);
-	
+
 	QString s = str.toLower();
 	if (s.size() % 2 != 0)
 		s.prepend('0');
-	
+
 	int j = 19;
-	
+
 	for (int i = s.size() - 1; i >= 0; i -= 2)
 	{
 		char left = s[i - 1].toLatin1();
 		char right = s[i].toLatin1();
 		result[j--] = (HexCharToUint8(left) << 4) | HexCharToUint8(right);
 	}
-	
+
 	return dht::Key(result);
 }
 
@@ -68,38 +67,38 @@ private slots:
 	{
 		bt::InitLog("keytest.log", false, true);
 	}
-	
+
 	void cleanupTestCase()
 	{
 	}
-	
+
 	void testAddition()
 	{
 		dht::Key a = KeyFromHexString("14455");
-		dht::Key b = KeyFromHexString("FFEEDD");	
+		dht::Key b = KeyFromHexString("FFEEDD");
 		dht::Key c = a + b;
 		QVERIFY(c == KeyFromHexString("1013332"));
-		
+
 		dht::Key d = a + 1;
 		QVERIFY(d == KeyFromHexString("14456"));
-		
+
 		dht::Key e = KeyFromHexString("FFFF") + 1;
 		QVERIFY(e == KeyFromHexString("10000"));
 	}
-	
+
 	void testSubtraction()
 	{
 		dht::Key a = KeyFromHexString("556677");
 		dht::Key b = KeyFromHexString("3384E6");
 		dht::Key c = a - b;
 		QVERIFY(c == KeyFromHexString("21E191"));
-		
+
 		dht::Key d = KeyFromHexString("550077");
 		dht::Key e = KeyFromHexString("3384E6");
 		dht::Key f = d - e;
 		QVERIFY(f == KeyFromHexString("217B91"));
 	}
-	
+
 	void testDivision()
 	{
 		dht::Key a = KeyFromHexString("550078");
@@ -107,7 +106,6 @@ private slots:
 		QVERIFY(b == KeyFromHexString("2A803C"));
 	}
 };
-
 
 QTEST_MAIN(KeyTest)
 

--- a/src/dht/tests/rpcmsgtest.cpp
+++ b/src/dht/tests/rpcmsgtest.cpp
@@ -17,7 +17,6 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  ***************************************************************************/
-
 #include <QtTest>
 #include <util/log.h>
 #include <util/error.h>
@@ -36,7 +35,7 @@ private:
 		Q_UNUSED(mtid);
 		return current_method;
 	}
-	
+
 private slots:
 	void initTestCase()
 	{
@@ -92,12 +91,12 @@ private slots:
 			idx++;
 		}
 	}
-	
+
 	void testPing()
 	{
 		const char* msg[] = {"d1:ad2:id20:abcdefghij0123456789e1:q4:ping1:t2:aa1:y1:qe", "d1:rd2:id20:mnopqrstuvwxyz123456e1:t2:aa1:y1:re", 0};
 		current_method = dht::PING;
-		
+
 		int idx = 0;
 		while (msg[idx])
 		{
@@ -117,17 +116,17 @@ private slots:
 			idx++;
 		}
 	}
-	
+
 	void testFindNode()
 	{
 		const char* msg[] = {
-			"d1:ad2:id20:abcdefghij01234567896:target20:mnopqrstuvwxyz123456e1:q9:find_node1:t2:aa1:y1:qe", 
-			"d1:rd2:id20:0123456789abcdefghij5:nodes9:def456...e1:t2:aa1:y1:re", 
+			"d1:ad2:id20:abcdefghij01234567896:target20:mnopqrstuvwxyz123456e1:q9:find_node1:t2:aa1:y1:qe",
+			"d1:rd2:id20:0123456789abcdefghij5:nodes9:def456...e1:t2:aa1:y1:re",
 			0
 		};
-		
+
 		current_method = dht::FIND_NODE;
-		
+
 		int idx = 0;
 		while (msg[idx])
 		{
@@ -147,7 +146,7 @@ private slots:
 			idx++;
 		}
 	}
-	
+
 	void testGetPeers()
 	{
 		const char* msg[] = {
@@ -157,7 +156,7 @@ private slots:
 			0
 		};
 		current_method = dht::GET_PEERS;
-		
+
 		int idx = 0;
 		while (msg[idx])
 		{
@@ -177,7 +176,7 @@ private slots:
 			idx++;
 		}
 	}
-	
+
 	void testAnnounce()
 	{
 		const char* msg[] = {

--- a/src/peer/peer.cpp
+++ b/src/peer/peer.cpp
@@ -532,7 +532,7 @@ namespace bt
                 stats.partial_seed = val->data().toInt() == 1;
             }
 
-            /*
+            /**
              * @author Fonic <https://github.com/fonic>
              *
              * If present, evaluate 'v' string of extended handshake message to

--- a/src/peer/peer.cpp
+++ b/src/peer/peer.cpp
@@ -534,7 +534,6 @@ namespace bt
 
             /**
              * @author Fonic <https://github.com/fonic>
-             *
              * If present, evaluate 'v' string of extended handshake message to
              * accurately identify client as suggested by BitTorrent Extension
              * Protocol, section 'handshake message'. This will override a prior

--- a/src/peer/peer.cpp
+++ b/src/peer/peer.cpp
@@ -539,7 +539,6 @@ namespace bt
              * accurately identify client as suggested by BitTorrent Extension
              * Protocol, section 'handshake message'. This will override a prior
              * identification based on peer ID (refer to src/peer/peerid.cpp).
-             *
              */
             if ((val = dict->getValue(QByteArrayLiteral("v"))))
             {

--- a/src/peer/peer.cpp
+++ b/src/peer/peer.cpp
@@ -531,6 +531,20 @@ namespace bt
             {
                 stats.partial_seed = val->data().toInt() == 1;
             }
+
+            /*
+             * @author Fonic <https://github.com/fonic>
+             *
+             * If present, evaluate 'v' string of extended handshake message to
+             * accurately identify client as suggested by BitTorrent Extension
+             * Protocol, section 'handshake message'. This will override a prior
+             * identification based on peer ID (refer to src/peer/peerid.cpp).
+             *
+             */
+            if ((val = dict->getValue(QByteArrayLiteral("v"))))
+            {
+                stats.client = val->data().toString();
+            }
         }
         catch (...)
         {


### PR DESCRIPTION
**I thoroughly revised the DHT codebase:**
- Implemented bootstrapping from well-known nodes (like most other torrent clients do) so that DHT is usable right away (i.e. when enabling it for the first time).
- Transferred lots of important hard-coded values to constants in header files. This is a first step, in a second step I would like to make those values configurable from within KTorrent
- Added comments for important constants, describing them and comparing their values to the specification and/or the [DHT reference implementation](https://github.com/bittorrent/libbtdht)
- Modified several important values (timeouts, minimum/maximum limits) according to the values proposed by the current DHT reference implementation
- General code cleanup (comments, newlines, whitespace-only lines etc.)

To test DHT bootstrapping, (re)move any existing KTorrent user configuration, start KTorrent and enable DHT in settings. Then, watch the DHT entry in the status bar and/or the debug output in the log/console. Bootstrapping should only take a couple of seconds. After that, the number of known nodes should be in the range of 50 - 100.