### PR TITLE
Fix open preview for small downloaded files

### DIFF
--- a/src/torrent/torrentcontrol.cpp
+++ b/src/torrent/torrentcontrol.cpp
@@ -1191,7 +1191,7 @@ namespace bt
             return false;
 
         const BitSet& bs = downloadedChunksBitSet();
-        for (Uint32 i = 0; i < preview_range; i++)
+        for (Uint32 i = 0; i < qMin(preview_range, bs.numOnBits()); i++)
         {
             if (!bs.get(i))
                 return false;


### PR DESCRIPTION
If preview size > file size, the message "Not enough data downloaded for opening the file" appears.
This commit check maximum available file size.