### PR TITLE
respect file priority when selecting preview chunks

### DIFF
--- a/src/diskio/chunk.h
+++ b/src/diskio/chunk.h
@@ -117,6 +117,14 @@ public:
         priority = newpriority;
     }
 
+    /// Is chunk part of a multimedia preview
+    bool isPreview() const
+    {
+        return priority == FIRST_PREVIEW_PRIORITY ||
+                priority == NORMAL_PREVIEW_PRIORITY ||
+                priority == LAST_PREVIEW_PRIORITY;
+    }
+
     /// Is chunk excluded
     bool isExcluded() const
     {

--- a/src/diskio/chunkmanager.h
+++ b/src/diskio/chunkmanager.h
@@ -254,6 +254,13 @@ public:
     void prioritise(Uint32 from, Uint32 to, Priority priority);
 
     /**
+     * Increases the priority of a range to preview priority.
+     * @param from First chunk in range
+     * @param to Last chunk in range
+     */
+    void prioritisePreview(Uint32 from, Uint32 to);
+
+    /**
      * Make sure that a range will not be downloaded.
      * @param from First chunk in range
      * @param to Last chunk in range

--- a/src/download/streamingchunkselector.cpp
+++ b/src/download/streamingchunkselector.cpp
@@ -50,7 +50,7 @@ void StreamingChunkSelector::init(ChunkManager *cman, Downloader *downer, PeerMa
 
     preview_chunks.clear();
     for (Uint32 i = 0; i <= range_end; i++)
-        if (cman->getChunk(i)->getPriority() == bt::PREVIEW_PRIORITY)
+        if (cman->getChunk(i)->isPreview())
             preview_chunks.insert(i);
 }
 
@@ -191,13 +191,13 @@ void StreamingChunkSelector::reincluded(bt::Uint32 from, bt::Uint32 to)
     initRange();
 
     for (Uint32 chunk = from; chunk <= to; chunk++)
-        if (cman->getChunk(chunk)->getPriority() == bt::PREVIEW_PRIORITY)
+        if (cman->getChunk(chunk)->isPreview())
             preview_chunks.insert(chunk);
 }
 
 void StreamingChunkSelector::reinsert(bt::Uint32 chunk)
 {
-    if (cman->getChunk(chunk)->getPriority() == bt::PREVIEW_PRIORITY)
+    if (cman->getChunk(chunk)->isPreview())
         preview_chunks.insert(chunk);
 
     bt::ChunkSelector::reinsert(chunk);

--- a/src/util/constants.h
+++ b/src/util/constants.h
@@ -38,9 +38,11 @@ typedef Uint64 TimeStamp;
 
 typedef enum {
     // also leave some room if we want to add new priorities in the future
-    PREVIEW_PRIORITY = 60,
+    FIRST_PREVIEW_PRIORITY = 55,
     FIRST_PRIORITY = 50,
+    NORMAL_PREVIEW_PRIORITY = 45,
     NORMAL_PRIORITY = 40,
+    LAST_PREVIEW_PRIORITY = 35,
     LAST_PRIORITY = 30,
     ONLY_SEED_PRIORITY = 20,
     EXCLUDED = 10,


### PR DESCRIPTION
Previously, `ChunkSelector` would select preview chunks ahead of all other chunks, regardless of file priority. This meant that files prioritized as "Last" would nevertheless have all of their preview chunks downloaded before all files prioritized as "First" or "Normal" had finished downloading. This contradicts user expectation, which is that scarce download bandwidth should not be devoted to files marked "Last" until all files prioritized as "First" and "Normal" have been completely downloaded.

This commit splits the existing `PREVIEW_PRIORITY` level into three priority levels: `FIRST_PREVIEW_PRIORITY`, `NORMAL_PREVIEW_PRIORITY`, and `LAST_PREVIEW_PRIORITY`. Chunks that `ChunkManager` determines to be preview chunks have their priority levels boosted to the preview priority level corresponding to their respective base priority level.

`ChunkSelector`'s algorithm receives an overhaul that eliminates the temporary `std::list` objects in favor of remembering the best (highest priority, least number of downloaders) chunk during the iteration and selecting that chunk if no chunk at the same priority level but with no downloaders is found. The logic is ultimately equivalent to that implemented in `leastPeers(…)` but will run faster since it requires no heap allocations. Also, the new algorithm will not fail to select a chunk that already has downloaders if there are no chunks that have no downloaders. This should keep `PieceDownloader`s busier.

**There is a companion PR for ktorrent.**